### PR TITLE
Add github action to publish docker image on release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,23 @@
+name: Docker Image CI
+
+on:
+  release:
+    type: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag gamefeeder:current
+    - name: Login to Docker
+      run: docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+    - name: Tag the Docker image as version
+      run: docker tag gamefeeder:current gamefeeder/gamefeeder:$(awk '/version/{gsub(/("|",)/,"",$2);print $2};' package.json)
+    - name: Publish the Docker image:version
+      run: docker push gamefeeder/gamefeeder:$(awk '/version/{gsub(/("|",)/,"",$2);print $2};' package.json)
+    - name: Tag the Docker image as latest
+      run: docker tag gamefeeder:current gamefeeder/gamefeeder:latest
+    - name: Publish the Docker image:latest
+      run: docker push gamefeeder/gamefeeder:latest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "valvegamesannouncerbot",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "description": "A notification bot for multiple Valve games, available on Discord and Telegram.",
   "main": "src/_main.ts",
   "scripts": {
@@ -51,6 +51,7 @@
     "@types/request-promise-native": "1.0.16",
     "@types/showdown": "1.9.3",
     "@types/xml2js": "0.4.5",
+    "@discordjs/uws": "10.149.0",
     "cheerio": "1.0.0-rc.3",
     "discord.js": "11.5.1",
     "escape-string-regexp": "2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -139,6 +139,11 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@discordjs/uws@10.149.0":
+  version "10.149.0"
+  resolved "https://registry.yarnpkg.com/@discordjs/uws/-/uws-10.149.0.tgz#5ec3d12aa140aea402ad8bfabeddb2986a371bb9"
+  integrity sha512-N1wjoAD2DOgzevqzyTOWTgyO2divX03JWNQx4JHm/jQ/BRzZNkhwVRO3RC5Guww+srdgs4Tw4gwrzlJrlOhq/Q==
+
 "@fimbul/bifrost@^0.17.0":
   version "0.17.0"
   resolved "https://registry.yarnpkg.com/@fimbul/bifrost/-/bifrost-0.17.0.tgz#f0383ba7e40992e3193dc87e2ddfde2ad62a9cf4"


### PR DESCRIPTION
**Description**:

This adds a github action that will publish a docker image tagged with the version and update the latest docker image on https://hub.docker.com/r/gamefeeder/gamefeeder/tags.

Also adds peer dependency of discord.js package

**Checklist**:

- [x] Tested the bot on both clients with a few commands
- [x] Updated the [`README`](README.md) if necessary
- [x] Updated the version string in the [`package.json`](package.json) if necessary
