### PR TITLE
Add missing commands to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ So far, we are providing the following commands:
 | `start`                                  | User       | Get started with the GameFeeder.                |
 | `help`                                   | User       | Display all available commands.                 |
 | `about`                                  | User       | Display information about this bot.             |
-| `settings`                               | User       | Display an overview of the settings you can configure for the bot. |
+| `settings`                               | User       | Display an overview of the settings you can     |
+                                           |            | configure for the bot.                          |
 | `games`                                  | User       | Display a list of all available games.          |
 | `subscribe <game name>`                  | Admin      | Subscribe to a game's feed.                     |
 | `unsubscribe <game name>`                | Admin      | Unsubscribe from a game's feed.                 |

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ So far, we are providing the following commands:
 | `help`                                   | User       | Display all available commands.                 |
 | `about`                                  | User       | Display information about this bot.             |
 | `settings`                               | User       | Display an overview of the settings you can     |
-                                           |            | configure for the bot.                          |
+|                                          |            | configure for the bot.                          |
 | `games`                                  | User       | Display a list of all available games.          |
 | `subscribe <game name>`                  | Admin      | Subscribe to a game's feed.                     |
 | `unsubscribe <game name>`                | Admin      | Unsubscribe from a game's feed.                 |

--- a/README.md
+++ b/README.md
@@ -58,8 +58,10 @@ So far, we are providing the following commands:
 
 | Command                                  | Permission | Summary                                         |
 | ---------------------------------------- | ---------- | ----------------------------------------------- |
+| `start`                                  | User       | Get started with the GameFeeder.                |
 | `help`                                   | User       | Display all available commands.                 |
 | `about`                                  | User       | Display information about this bot.             |
+| `settings`                               | User       | Display an overview of the settings you can configure for the bot. |
 | `games`                                  | User       | Display a list of all available games.          |
 | `subscribe <game name>`                  | Admin      | Subscribe to a game's feed.                     |
 | `unsubscribe <game name>`                | Admin      | Unsubscribe from a game's feed.                 |


### PR DESCRIPTION
**Description**:

Add "start" and "settings" commands to README. Closes #145.

**Checklist**:

- [x] Tested the bot on both clients with a few commands
- [x] Updated the [`README`](README.md) if necessary
- [x] Updated the version string in the [`package.json`](package.json) if necessary
