### PR TITLE
Add indicator to cut off messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gamefeeder",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "A notification bot for several games, available on Discord and Telegram.",
   "main": "src/_main.ts",
   "scripts": {

--- a/src/bot_discord.ts
+++ b/src/bot_discord.ts
@@ -12,6 +12,7 @@ import Command from './command';
 import ConfigManager from './config_manager';
 import BotNotification from './notification';
 import MDRegex from './regex';
+import { StrUtil } from './util';
 
 export default class DiscordBot extends BotClient {
   private static standardBot: DiscordBot;
@@ -169,11 +170,8 @@ export default class DiscordBot extends BotClient {
     // Description
     if (notification.description) {
       const descriptionMD = DiscordBot.msgFromMarkdown(notification.description, true);
-      if (descriptionMD.length > 2048) {
-        embed.setDescription(descriptionMD.substring(0, 2048));
-      } else {
-        embed.setDescription(descriptionMD);
-      }
+      // 2048 is the maximum notification length
+      embed.setDescription(StrUtil.naturalLimit(descriptionMD, 2048));
     }
     // Footer
     if (notification.footer) {

--- a/src/bot_telegram.ts
+++ b/src/bot_telegram.ts
@@ -6,6 +6,7 @@ import Command from './command';
 import ConfigManager from './config_manager';
 import BotNotification from './notification';
 import MDRegex, { bold, seperator } from './regex';
+import { StrUtil } from './util';
 
 export default class TelegramBot extends BotClient {
   private static standardBot: TelegramBot;
@@ -193,9 +194,9 @@ export default class TelegramBot extends BotClient {
         text = TelegramBot.msgFromMarkdown(message.toMDString());
       }
 
-      if (text.length > 2048) {
-        text = text.substring(0, 2048);
-      }
+      // 2048 is the maximum notification length
+      text = StrUtil.naturalLimit(text, 2048);
+
       try {
         await this.bot.sendMessage(channel.id, text, {
           disable_web_page_preview: !templateFound,

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -1,4 +1,4 @@
-import { mapAsync, filterAsync, naturalJoin, ObjUtil } from './util';
+import { mapAsync, filterAsync, naturalJoin, ObjUtil, StrUtil } from './util';
 
 describe('Util', () => {
   describe('map async', () => {
@@ -101,6 +101,68 @@ describe('Util', () => {
         const actual = ObjUtil.getInnerObject(object);
 
         expect(actual).toEqual(expected);
+      });
+    });
+  });
+
+  describe('String util', () => {
+    describe('limit string', () => {
+      test('should not limit', () => {
+        const testStr = 'Test message';
+        const expected = 'Test message';
+        const actual = StrUtil.limit(testStr, 12);
+
+        expect(actual).toEqual(expected);
+      });
+
+      test('has to limit', () => {
+        const testStr = 'Test message';
+        const expected = 'Test messag';
+        const actual = StrUtil.limit(testStr, 11);
+
+        expect(actual).toEqual(expected);
+      });
+    });
+
+    describe('natural limit string', () => {
+      test('should not limit with default indicator', () => {
+        const testStr = 'Test message';
+        const expected = 'Test message';
+        const actual = StrUtil.naturalLimit(testStr, 12);
+
+        expect(actual).toEqual(expected);
+      });
+
+      test('has to limit with default indicator', () => {
+        const testStr = 'Test message';
+        const expected = 'Test mes...';
+        const actual = StrUtil.naturalLimit(testStr, 11);
+
+        expect(actual).toEqual(expected);
+      });
+
+      test('has to limit with custom indicator', () => {
+        const testStr = 'Test message';
+        const expected = 'Test  [...]';
+        const actual = StrUtil.naturalLimit(testStr, 11, ' [...]');
+
+        expect(actual).toEqual(expected);
+      });
+
+      test('with too long default indicator', () => {
+        const testStr = 'Test message';
+
+        expect(() => {
+          StrUtil.naturalLimit(testStr, 2);
+        }).toThrow();
+      });
+
+      test('with too long custom indicator', () => {
+        const testStr = 'Test message';
+
+        expect(() => {
+          StrUtil.naturalLimit(testStr, 5, ' [...]');
+        }).toThrow();
       });
     });
   });

--- a/src/util.ts
+++ b/src/util.ts
@@ -40,6 +40,41 @@ export function naturalJoin(array: string[], seperator?: string): string {
   return array.slice(0, array.length - 1).join(sep) + ' and ' + array[array.length - 1];
 }
 
+/** Utility functions for strings. */
+export class StrUtil {
+  /** Limits the given string to the given maximum length.
+   *
+   * @param str - The string to limit.
+   * @param limit - The maximum length of the string.
+   */
+  public static limit(str: string, limit: number): string {
+    if (str.length > limit) {
+      return str.substring(0, limit);
+    }
+    return str;
+  }
+
+  /**Limits the given string to the given maximum length naturally, by adding an indicator.
+   * E.g. Text message => Text messa...
+   *
+   * @param str - The string to limit.
+   * @param limit - The maximum length of the string.
+   * @param indicator - The indicator to use when the string is too long.
+   */
+  public static naturalLimit(str: string, limit: number, indicator?: string): string {
+    const newIndicator = indicator == null ? '...' : indicator;
+
+    if (newIndicator.length > limit) {
+      throw new Error('The indicator must not be longer than the limit.');
+    }
+    if (str.length > limit) {
+      const cutStr = this.limit(str, limit - newIndicator.length);
+      return cutStr + newIndicator;
+    }
+    return str;
+  }
+}
+
 export class ObjUtil {
   public static keys(object: any): string[] {
     if (!(object instanceof Object)) {


### PR DESCRIPTION
**Description**:

When messages are cut off due to the maximum notification length, it is indicated by appending `...`.
Closes #91.

**Checklist**:

- [x] Tested the bot on both clients with a few commands
- [x] Updated the [`README`](README.md) if necessary
- [x] Updated the version string in the [`package.json`](package.json) if necessary
