### PR TITLE
Fix notification commands only sending the first paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ So far, we are providing the following commands:
 | `notifyAll <message>`                    | Owner      | Send a message to all subscribers.              |
 | `notifyGameSubs (<game name>) <message>` | Owner      | Send a message to all subscribers of a game.    |
 
+**Note:** The messages in the notification commands should be provided in the raw markdown format, they will be reformatted for the different clients. Discord should be used for these commands, as some formatting information gets lost in Telegram (when Telegram uses the same format).
+
 #### Permissions
 
 - **User**: Any user can execute this command

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gamefeeder",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "A notification bot for several games, available on Discord and Telegram.",
   "main": "src/_main.ts",
   "scripts": {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -323,7 +323,7 @@ const notifyAllCmd = new Command(
   'Notify All',
   'Notify all subscribed users.',
   'notifyAll <message>',
-  '(notifyAll(Subs)?)\\s*(?<message>.*)',
+  '(notifyAll(Subs)?)\\s*(?<message>(?:.|\\s)*)$',
   (bot, channel, user, match: any) => {
     let { message } = match.groups;
     message = message ? message.trim() : '';
@@ -353,7 +353,7 @@ const notifyGameSubsCmd = new Command(
   'Notify Game Subs',
   'Notify all subs of a game.',
   'notifyGameSubs (<game name>) <message>',
-  '(notify(Game)?Subs)\\s*(\\((?<alias>.*)\\))?\\s*(?<message>.*)\\s*$',
+  '(notify(Game)?Subs)\\s*(\\((?<alias>.*)\\))?\\s*(?<message>(?:.|\\s)*)\\s*$',
   (bot, channel, user, match: any) => {
     let { alias, message } = match.groups;
     alias = alias ? alias.trim() : '';


### PR DESCRIPTION
**Description**:
The notification commands now also match whitespace, so that all paragraphs are sent.
Closes #131.

**Checklist**:

- [x] Tested the bot on both clients with a few commands
- [x] Updated the [`README`](README.md) if necessary
- [x] Updated the version string in the [`package.json`](package.json) if necessary
