### PR TITLE
Fix md to html conversion throwing an error on empty content

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gamefeeder",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "A notification bot for several games, available on Discord and Telegram.",
   "main": "src/_main.ts",
   "repository": {

--- a/src/rss.ts
+++ b/src/rss.ts
@@ -7,7 +7,7 @@ import PreProcessor from './pre_processor';
 
 export default class RSS {
   public static logger = new Logger('RSS');
-  private parser: any;
+  private parser: RSSParser;
 
   constructor() {
     this.parser = new RSSParser();
@@ -28,7 +28,7 @@ export default class RSS {
       for (const item of feed.items) {
         const creator = item.creator || '';
         const link = item.link || '';
-        let content = item.content;
+        let content = item.content || '';
         const postDate = new Date(item.isoDate) || new Date();
 
         // Apply pre-processing
@@ -42,7 +42,7 @@ export default class RSS {
 
         if (title && content) {
           const rssItem = new RSSItem(title, creator, link, content, postDate, {
-            link: feed,
+            link: feed.link,
             name: feed.title,
             source: '',
           });
@@ -57,7 +57,11 @@ export default class RSS {
 
       return feedItems;
     } catch (error) {
-      RSS.logger.error(`Failed to parse feed url '${url}':\n${error}`);
+      if (error instanceof Error) {
+        RSS.logger.error(`Failed to parse feed url '${url}':\n${error.stack}`);
+      } else {
+        RSS.logger.error(`Failed to parse feed url '${url}':\n${error}`);
+      }
       return [];
     }
   }


### PR DESCRIPTION
**Description**:

Fixed RSS HTML to MD conversion failing on `undefined` content.
Closes #159.

**Checklist**:

- [x] Tested the bot on both clients with a few commands
- [x] Updated the [`README`](README.md) if necessary
- [x] Updated the version string in the [`package.json`](package.json) if necessary
