### PR TITLE
Handle missing permissions

### DIFF
--- a/.github/workflows/tag-flow.yml
+++ b/.github/workflows/tag-flow.yml
@@ -1,4 +1,4 @@
-name: Tag Release
+name: tag-flow
 
 on:
   push:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ You will need to create a Discord bot if you want to test out the Discord notifi
 
 To do that, first follow [this](https://discordpy.readthedocs.io/en/latest/discord.html) tutorial to create an application with a bot. This provide you with a bot token. Copy & paste that in the `config/api_config.json`, in the `bots.discord.token` field. Make sure to take the bot's token and not the application's client secret, it won't work otherwise.
 
-Some commands require `OWNER` permissions. To access those, you need to add your userID to `config/api_config.json` in the `bots.discord.owners` array.
+Some commands require the `OWNER` role. To access those, you need to add your userID to `config/api_config.json` in the `bots.discord.owners` array.
 To find out your ID, you can follow [this](https://support.discordapp.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID-) guide.
 
 ### Telegram Bot
@@ -44,7 +44,7 @@ You will need to create a Telegram bot if you want to test out the Telegram noti
 
 To do that, first follow [this](https://core.telegram.org/bots#3-how-do-i-create-a-bot) tutorial to create the bot. This will give you a token. Copy & paste that in the `config/api_config.json`, in the `bots.telegram.token` field.
 
-Some commands require `OWNER` permissions. To access those, you need to add your userID to `config/api_config.json` in the `bots.telegram.owners` array.
+Some commands require the `OWNER` role. To access those, you need to add your userID to `config/api_config.json` in the `bots.telegram.owners` array.
 To find out your ID, you can use [@get_id_bot](https://telegram.me/get_id_bot).
 
 ### Reddit API

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A TypeScript port of the [dota2UpdatesBot](https://github.com/zachkont/dotaUpdat
     - [Telegram](#telegram)
     - [Local setup](#local-setup)
   - [Commands](#commands)
-    - [Permissions](#permissions)
+    - [Roles](#roles)
   - [Games](#games)
   - [Contributing](#contributing)
 - [Miscellaneous](#miscellaneous)
@@ -56,28 +56,28 @@ So far, we are providing the following commands:
 - The default prefix on Discord is `!`.
 - You can also use the bot's tag as prefix.
 
-| Command                                    | Permission | Summary                                                                         |
-| ------------------------------------------ | ---------- | ------------------------------------------------------------------------------- |
-| `start`                                    | User       | Get started with the GameFeeder.                                                |
-| `help`                                     | User       | Display all available commands.                                                 |
-| `about`                                    | User       | Display information about this bot.                                             |
-| `settings`                                 | User       | Display an overview of the settings you can configure for the bot.              |
-| `games`                                    | User       | Display a list of all available games.                                          |
-| `stats`                                    | User       | Display some stats about the bot.                                               |
-| `ping`                                     | User       | Test the delay of the bot.                                                      |
-| `debug`                                    | User       | Display useful debug information.                                               |
-| `flip`                                     | User       | Flip a coin.                                                                    |
-| `roll <dice count> <dice type> <modifier>` | User       | Roll some dice.                                                                 |
-| `subscribe <game name>`                    | Admin      | Subscribe to a game's feed.                                                     |
-| `unsubscribe <game name>`                  | Admin      | Unsubscribe from a game's feed.                                                 |
-| `prefix <new prefix>`                      | Admin      | Change the prefix the bot uses on this channel.                                 |
-| `notifyAll <message>`                      | Owner      | Send a message to all subscribers.                                              |
-| `notifyGameSubs (<game name>) <message>`   | Owner      | Send a message to all subscribers of a game.                                    |
-| `telegramCmds`                             | Owner      | Simplifies the command registration on Telegram by printing the command string. |
+| Command                                    | Role  | Summary                                                                         |
+| ------------------------------------------ | ----- | ------------------------------------------------------------------------------- |
+| `start`                                    | User  | Get started with the GameFeeder.                                                |
+| `help`                                     | User  | Display all available commands.                                                 |
+| `about`                                    | User  | Display information about this bot.                                             |
+| `settings`                                 | User  | Display an overview of the settings you can configure for the bot.              |
+| `games`                                    | User  | Display a list of all available games.                                          |
+| `stats`                                    | User  | Display some stats about the bot.                                               |
+| `ping`                                     | User  | Test the delay of the bot.                                                      |
+| `debug`                                    | User  | Display useful debug information.                                               |
+| `flip`                                     | User  | Flip a coin.                                                                    |
+| `roll <dice count> <dice type> <modifier>` | User  | Roll some dice.                                                                 |
+| `subscribe <game name>`                    | Admin | Subscribe to a game's feed.                                                     |
+| `unsubscribe <game name>`                  | Admin | Unsubscribe from a game's feed.                                                 |
+| `prefix <new prefix>`                      | Admin | Change the prefix the bot uses on this channel.                                 |
+| `notifyAll <message>`                      | Owner | Send a message to all subscribers.                                              |
+| `notifyGameSubs (<game name>) <message>`   | Owner | Send a message to all subscribers of a game.                                    |
+| `telegramCmds`                             | Owner | Simplifies the command registration on Telegram by printing the command string. |
 
 **Note:** The messages in the notification commands should be provided in the raw markdown format, they will be reformatted for the different clients. Discord should be used for these commands, as some formatting information gets lost in Telegram (when Telegram uses the same format).
 
-#### Permissions
+#### Roles
 
 - **User**: Any user can execute this command
 - **Admin**: Only admins on this server can execute this command

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gamefeeder",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "A notification bot for several games, available on Discord and Telegram.",
   "main": "src/_main.ts",
   "repository": {

--- a/src/_main.ts
+++ b/src/_main.ts
@@ -52,6 +52,8 @@ export default class Main {
         } else {
           bot.logger.warn('Bot did not start. Did you provide a token in "bot_config.json"?');
         }
+        // Clean up dead bot channels
+        await bot.removeChannelsWithoutWritePermissions();
       } else {
         bot.logger.debug('Autostart disabled.');
       }

--- a/src/_main.ts
+++ b/src/_main.ts
@@ -52,8 +52,6 @@ export default class Main {
         } else {
           bot.logger.warn('Bot did not start. Did you provide a token in "bot_config.json"?');
         }
-        // Clean up dead bot channels
-        await bot.removeChannelsWithoutWritePermissions();
       } else {
         bot.logger.debug('Autostart disabled.');
       }

--- a/src/bots/bot.ts
+++ b/src/bots/bot.ts
@@ -182,6 +182,9 @@ export default abstract class BotClient {
     return false;
   }
 
+  /** Gets the bot user. */
+  public abstract async getUser(): Promise<User>;
+
   /** Get the number of users in a given channel.
    *
    * @param channel - The channel to count the users in.

--- a/src/bots/bot.ts
+++ b/src/bots/bot.ts
@@ -200,14 +200,18 @@ export default abstract class BotClient {
     const channels = this.getBotChannels();
 
     // Iterate through all the channels
+    let removeCount = 0;
     for (const channel of channels) {
       const permissions = await this.getUserPermissions(await this.getUser(), channel);
       if (!permissions.canWrite) {
         // The bot can not write to this channel, remove channel data
         if (this.removeData(channel)) {
-          this.logger.warn(`Cleaning up channel without write access.`);
+          removeCount += 1;
         }
       }
+    }
+    if (removeCount > 0) {
+      this.logger.warn(`Cleaning up ${removeCount} channel(s) without write access.`);
     }
   }
 

--- a/src/bots/bot.ts
+++ b/src/bots/bot.ts
@@ -315,6 +315,12 @@ export default abstract class BotClient {
       }
     }
   }
+
+  /** Called when the bot is removed from the given channel. */
+  public async onRemoved(channel: Channel) {
+    this.removeData(channel);
+    this.logger.debug(`Bot removed from channel, removing channel data.`);
+  }
 }
 
 export { BotClient };

--- a/src/bots/bot.ts
+++ b/src/bots/bot.ts
@@ -5,6 +5,7 @@ import DataManager from '../managers/data_manager';
 import Game from '../game';
 import Notification from '../notifications/notification';
 import Logger from '../logger';
+import Permissions from '../permissions';
 
 export default abstract class BotClient {
   /** The internal name of the bot. */
@@ -72,6 +73,13 @@ export default abstract class BotClient {
    * @param channel - The channel to get the role on.
    */
   public abstract async getUserRole(user: User, channel: Channel): Promise<UserRole>;
+
+  /** Gets the permissions of a user on a given channel.
+   *
+   * @param user - The user to get the permissions of.
+   * @param channel - The channel to get the permissions on.
+   */
+  public abstract async getUserPermissions(user: User, channel: Channel): Promise<Permissions>;
 
   /** Gets a list of the owners of the bot.
    *

--- a/src/bots/bot.ts
+++ b/src/bots/bot.ts
@@ -162,6 +162,26 @@ export default abstract class BotClient {
     return false;
   }
 
+  /** Removes the data of a channel.
+   *
+   * @param  {Channel} channel - The channel to remove the data from.
+   */
+  public removeData(channel: Channel): boolean {
+    const subscribers = DataManager.getSubscriberData();
+    const subs = subscribers[this.name];
+
+    // Check if the channel has an entry
+    for (let i = 0; i < subs.length; i++) {
+      const sub = subs[i];
+      if (channel.isEqual(sub.id)) {
+        // Remove the channel
+        subs.splice(i, 1);
+        return true;
+      }
+    }
+    return false;
+  }
+
   /** Get the number of users in a given channel.
    *
    * @param channel - The channel to count the users in.

--- a/src/bots/bot.ts
+++ b/src/bots/bot.ts
@@ -176,6 +176,11 @@ export default abstract class BotClient {
       if (channel.isEqual(sub.id)) {
         // Remove the channel
         subs.splice(i, 1);
+
+        // Save the changes
+        subscribers[this.name] = subs;
+        DataManager.setSubscriberData(subscribers);
+
         return true;
       }
     }

--- a/src/bots/bot.ts
+++ b/src/bots/bot.ts
@@ -1,4 +1,4 @@
-import User, { UserPermission } from '../user';
+import User, { UserRole } from '../user';
 import Channel from '../channel';
 import Command from '../commands/command';
 import DataManager from '../managers/data_manager';
@@ -66,12 +66,12 @@ export default abstract class BotClient {
    */
   public abstract stop(): void;
 
-  /** Gets the permission of a user on a given channel.
+  /** Gets the role of a user on a given channel.
    *
-   * @param user - The user to get the permission of.
-   * @param channel - The channel to get the permission on.
+   * @param user - The user to get the role of.
+   * @param channel - The channel to get the role on.
    */
-  public abstract async getUserPermission(user: User, channel: Channel): Promise<UserPermission>;
+  public abstract async getUserRole(user: User, channel: Channel): Promise<UserRole>;
 
   /** Gets a list of the owners of the bot.
    *

--- a/src/bots/bot.ts
+++ b/src/bots/bot.ts
@@ -93,7 +93,15 @@ export default abstract class BotClient {
    * @param  {Game} game - The game to subscribe to.
    * @returns True, if the subscription was successful, else false.
    */
-  public addSubscriber(channel: Channel, game: Game): boolean {
+  public async addSubscriber(channel: Channel, game: Game): Promise<boolean> {
+    // Check if the bot can write to this channel
+    const permissions = await this.getUserPermissions(await this.getUser(), channel);
+    if (!permissions.canWrite) {
+      if (this.removeData(channel)) {
+        this.logger.warn(`Can't write to channel, removing all data.`);
+      }
+      return false;
+    }
     const subscribers = DataManager.getSubscriberData();
     const channels = subscribers[this.name];
 

--- a/src/bots/bot.ts
+++ b/src/bots/bot.ts
@@ -318,8 +318,9 @@ export default abstract class BotClient {
 
   /** Called when the bot is removed from the given channel. */
   public async onRemoved(channel: Channel) {
-    this.removeData(channel);
-    this.logger.debug(`Bot removed from channel, removing channel data.`);
+    if (this.removeData(channel)) {
+      this.logger.debug(`Bot removed from channel, removing channel data.`);
+    }
   }
 }
 

--- a/src/bots/bot.ts
+++ b/src/bots/bot.ts
@@ -195,6 +195,22 @@ export default abstract class BotClient {
     return false;
   }
 
+  /** Removes the data of all channels without write permissions. */
+  public async removeChannelsWithoutWritePermissions() {
+    const channels = this.getBotChannels();
+
+    // Iterate through all the channels
+    for (const channel of channels) {
+      const permissions = await this.getUserPermissions(await this.getUser(), channel);
+      if (!permissions.canWrite) {
+        // The bot can not write to this channel, remove channel data
+        if (this.removeData(channel)) {
+          this.logger.warn(`Cleaning up channel without write access.`);
+        }
+      }
+    }
+  }
+
   /** Gets the bot user. */
   public abstract async getUser(): Promise<User>;
 

--- a/src/bots/discord.ts
+++ b/src/bots/discord.ts
@@ -52,6 +52,11 @@ export default class DiscordBot extends BotClient {
     return `<@${this.bot.user.id}>`;
   }
 
+  public async getUser(): Promise<User> {
+    const userID = this.bot.user.id;
+    return new User(this, userID);
+  }
+
   public async getChannelUserCount(channel: Channel): Promise<number> {
     const discordChannel = this.bot.channels.get(channel.id);
 
@@ -211,6 +216,7 @@ export default class DiscordBot extends BotClient {
     try {
       return await this.sendToChannel(channel, '', embed);
     } catch (error) {
+      this.logger.error(`Failed to send message:\n${error}`);
       return false;
     }
   }

--- a/src/bots/discord.ts
+++ b/src/bots/discord.ts
@@ -1,6 +1,6 @@
 import DiscordAPI, { DMChannel, GroupDMChannel, TextChannel } from 'discord.js';
 import { BotClient } from './bot';
-import User, { UserPermission } from '../user';
+import User, { UserRole } from '../user';
 import Channel from '../channel';
 import Command from '../commands/command';
 import ConfigManager from '../managers/config_manager';
@@ -110,27 +110,27 @@ export default class DiscordBot extends BotClient {
     return userCount;
   }
 
-  public async getUserPermission(user: User, channel: Channel): Promise<UserPermission> {
+  public async getUserRole(user: User, channel: Channel): Promise<UserRole> {
     // Check if the user is one of the owners
     const ownerIds = (await this.getOwners()).map((owner) => owner.id);
     if (ownerIds.includes(user.id)) {
-      return UserPermission.OWNER;
+      return UserRole.OWNER;
     }
 
     const discordChannel = this.bot.channels.get(channel.id);
     // Check if the user has default admin rights
     if (discordChannel instanceof DMChannel || discordChannel instanceof GroupDMChannel) {
-      return UserPermission.ADMIN;
+      return UserRole.ADMIN;
     }
     if (discordChannel instanceof TextChannel) {
       // Check if the user is an admin on this channel
       const discordUser = discordChannel.members.get(user.id);
       if (discordUser.hasPermission(8)) {
-        return UserPermission.ADMIN;
+        return UserRole.ADMIN;
       }
     }
     // The user is just a regular user
-    return UserPermission.USER;
+    return UserRole.USER;
   }
 
   public async getOwners(): Promise<User[]> {

--- a/src/bots/discord.ts
+++ b/src/bots/discord.ts
@@ -277,9 +277,6 @@ export default class DiscordBot extends BotClient {
   public async sendMessage(channel: Channel, message: string | Notification): Promise<boolean> {
     // Check if the bot can write to this channel
     const permissions = await this.getUserPermissions(await this.getUser(), channel);
-    this.logger.debug(
-      `Permissions: W: ${permissions.canWrite} | E: ${permissions.canEdit} | P: ${permissions.canPin}`,
-    );
     if (!permissions.canWrite) {
       if (this.removeData(channel)) {
         this.logger.warn(`Can't write to channel, removing all data.`);

--- a/src/bots/discord.ts
+++ b/src/bots/discord.ts
@@ -154,9 +154,9 @@ export default class DiscordBot extends BotClient {
     } else if (discordChannel instanceof TextChannel) {
       // Check for the permissions
       const discordUser = discordChannel.members.get(user.id);
-      canWrite = discordUser.permissions.has('SEND_MESSAGES');
-      canEdit = discordUser.hasPermission(8192);
-      canPin = discordUser.hasPermission(8192);
+      canWrite = discordChannel.permissionsFor(discordUser).has(['SEND_MESSAGES', 'VIEW_CHANNEL']);
+      canEdit = discordChannel.permissionsFor(discordUser).has('MANAGE_MESSAGES');
+      canPin = discordChannel.permissionsFor(discordUser).has('MANAGE_MESSAGES');
     } else {
       this.logger.error(`Unecpected Discord channel type.`);
       canWrite = false;

--- a/src/bots/discord.ts
+++ b/src/bots/discord.ts
@@ -216,7 +216,9 @@ export default class DiscordBot extends BotClient {
     this.bot.on('message', async (msg) => {
       const channel = this.getChannelByID(msg.channel.id);
       const user = new User(this, msg.author.id);
-      const timestamp = msg.createdAt;
+      const now = new Date();
+      // Ensure proper timestamp
+      const timestamp = msg.createdAt > now ? now : msg.createdAt;
       const content = msg.toString();
 
       const reg = await command.getRegExp(channel);

--- a/src/bots/discord.ts
+++ b/src/bots/discord.ts
@@ -160,16 +160,21 @@ export default class DiscordBot extends BotClient {
     }
 
     if (discordChannel instanceof TextChannel) {
-      // Check for the permissions
-      const discordUser = discordChannel.members.get(user.id);
-      const discordPermissions = discordChannel.permissionsFor(discordUser);
+      try {
+        // Check for the permissions
+        const discordUser = discordChannel.members.get(user.id);
+        const discordPermissions = discordChannel.permissionsFor(discordUser);
 
-      const hasAccess = discordPermissions.has(['VIEW_CHANNEL', 'READ_MESSAGES']);
-      const canWrite = hasAccess && discordPermissions.has('SEND_MESSAGES');
-      const canEdit = hasAccess && discordPermissions.has('MANAGE_MESSAGES');
-      const canPin = hasAccess && discordPermissions.has('MANAGE_MESSAGES');
+        const hasAccess = discordPermissions.has(['VIEW_CHANNEL', 'READ_MESSAGES']);
+        const canWrite = hasAccess && discordPermissions.has('SEND_MESSAGES');
+        const canEdit = hasAccess && discordPermissions.has('MANAGE_MESSAGES');
+        const canPin = hasAccess && discordPermissions.has('MANAGE_MESSAGES');
 
-      return new Permissions(hasAccess, canWrite, canEdit, canPin);
+        return new Permissions(hasAccess, canWrite, canEdit, canPin);
+      } catch (error) {
+        this.logger.error(`Failed to get permissions for text channel:\n${error}`);
+        throw error;
+      }
     }
 
     this.logger.error(`Unecpected Discord channel type: ${discordChannel}`);
@@ -177,7 +182,7 @@ export default class DiscordBot extends BotClient {
   }
 
   /** Determines if the user can send embedded links.
-   *
+   *SS
    * @param user - The user to get the permission for.
    * @param channel - The channel to get the permission on.
    */

--- a/src/bots/discord.ts
+++ b/src/bots/discord.ts
@@ -162,10 +162,11 @@ export default class DiscordBot extends BotClient {
     } else if (discordChannel instanceof TextChannel) {
       // Check for the permissions
       const discordUser = discordChannel.members.get(user.id);
-      hasAccess = discordChannel.permissionsFor(discordUser).has(['VIEW_CHANNEL', 'READ_MESSAGES']);
-      canWrite = hasAccess && discordChannel.permissionsFor(discordUser).has('SEND_MESSAGES');
-      canEdit = hasAccess && discordChannel.permissionsFor(discordUser).has('MANAGE_MESSAGES');
-      canPin = hasAccess && discordChannel.permissionsFor(discordUser).has('MANAGE_MESSAGES');
+      const discordPermissions = discordChannel.permissionsFor(discordUser);
+      hasAccess = discordPermissions.has(['VIEW_CHANNEL', 'READ_MESSAGES']);
+      canWrite = hasAccess && discordPermissions.has('SEND_MESSAGES');
+      canEdit = hasAccess && discordPermissions.has('MANAGE_MESSAGES');
+      canPin = hasAccess && discordPermissions.has('MANAGE_MESSAGES');
     } else {
       this.logger.error(`Unecpected Discord channel type: ${discordChannel}`);
       hasAccess = false;

--- a/src/bots/discord.ts
+++ b/src/bots/discord.ts
@@ -112,7 +112,7 @@ export default class DiscordBot extends BotClient {
       channels,
       async (botChannel) => await botChannel.getUserCount(),
     );
-    const userCount = userCounts.reduce((prevValue, curValue) => prevValue + curValue);
+    const userCount = userCounts.reduce((prevValue, curValue) => prevValue + curValue, 0);
     return userCount;
   }
 

--- a/src/bots/discord.ts
+++ b/src/bots/discord.ts
@@ -147,7 +147,13 @@ export default class DiscordBot extends BotClient {
     let canEdit;
     let canPin;
 
-    if (discordChannel instanceof DMChannel) {
+    if (!discordChannel) {
+      // The user has been kicked from the channel
+      hasAccess = false;
+      canWrite = false;
+      canEdit = false;
+      canPin = false;
+    } else if (discordChannel instanceof DMChannel) {
       // You always have all permissions in DM and group channels
       hasAccess = true;
       canWrite = true;
@@ -161,7 +167,7 @@ export default class DiscordBot extends BotClient {
       canEdit = hasAccess && discordChannel.permissionsFor(discordUser).has('MANAGE_MESSAGES');
       canPin = hasAccess && discordChannel.permissionsFor(discordUser).has('MANAGE_MESSAGES');
     } else {
-      this.logger.error(`Unecpected Discord channel type.`);
+      this.logger.error(`Unecpected Discord channel type: ${discordChannel}`);
       hasAccess = false;
       canWrite = false;
       canEdit = false;

--- a/src/bots/telegram.ts
+++ b/src/bots/telegram.ts
@@ -196,7 +196,8 @@ export default class TelegramBot extends BotClient {
       const user = new User(this, userID);
       const content = msg.text;
       // Convert from Unix time to date
-      const timestamp = new Date(msg.date * 1000 + 500);
+      const timeNumber = Math.min(Date.now(), msg.date * 1000 + 500);
+      const timestamp = new Date(timeNumber);
 
       const reg = await command.getRegExp(channel);
       // Run regex on the msg

--- a/src/bots/telegram.ts
+++ b/src/bots/telegram.ts
@@ -1,6 +1,6 @@
 import TelegramAPI from 'node-telegram-bot-api';
 import { BotClient } from './bot';
-import User, { UserPermission } from '../user';
+import User, { UserRole } from '../user';
 import Channel from '../channel';
 import Command from '../commands/command';
 import ConfigManager from '../managers/config_manager';
@@ -57,35 +57,35 @@ export default class TelegramBot extends BotClient {
     }
   }
 
-  public async getUserPermission(user: User, channel: Channel): Promise<UserPermission> {
+  public async getUserRole(user: User, channel: Channel): Promise<UserRole> {
     try {
       // Channel messages don't have an author, we assigned the user id channelAuthorID
       // A bit hacky, but should work for now
       if (user.id === this.channelAuthorID) {
-        // If you can write in a channel, you get admin permissions
-        return UserPermission.ADMIN;
+        // If you can write in a channel, you have an admin role
+        return UserRole.ADMIN;
       }
       // Check if user is owner
       const ownerIds = (await this.getOwners()).map((owner) => owner.id);
       if (ownerIds.includes(user.id)) {
-        return UserPermission.OWNER;
+        return UserRole.OWNER;
       }
       // Check if user has default admin rights
       const chat = await this.bot.getChat(channel.id);
       if (chat.all_members_are_administrators || chat.type === 'private') {
-        return UserPermission.ADMIN;
+        return UserRole.ADMIN;
       }
       // Check if user is an admin on this channel
       const chatAdmins = (await this.bot.getChatAdministrators(channel.id)) || [];
       const adminIds = chatAdmins.map((admin) => admin.user.id.toString());
       if (adminIds.includes(user.id)) {
-        return UserPermission.ADMIN;
+        return UserRole.ADMIN;
       }
     } catch (error) {
       this.logger.error(`Failed to get chat admins:\n${error}`);
     }
     // the user is just a regular user
-    return UserPermission.USER;
+    return UserRole.USER;
   }
 
   public async getChannelUserCount(channel: Channel): Promise<number> {

--- a/src/bots/telegram.ts
+++ b/src/bots/telegram.ts
@@ -167,7 +167,7 @@ export default class TelegramBot extends BotClient {
       channels,
       async (botChannel) => await botChannel.getUserCount(),
     );
-    const userCount = userCounts.reduce((prevValue, curValue) => prevValue + curValue);
+    const userCount = userCounts.reduce((prevValue, curValue) => prevValue + curValue, 0);
     return userCount;
   }
 

--- a/src/bots/telegram.ts
+++ b/src/bots/telegram.ts
@@ -58,6 +58,12 @@ export default class TelegramBot extends BotClient {
     }
   }
 
+  public async getUser(): Promise<User> {
+    const telegramUser = await this.bot.getMe();
+    const userID = telegramUser.id.toString();
+    return new User(this, userID);
+  }
+
   public async getUserRole(user: User, channel: Channel): Promise<UserRole> {
     try {
       // Channel messages don't have an author, we assigned the user id channelAuthorID

--- a/src/bots/telegram.ts
+++ b/src/bots/telegram.ts
@@ -253,9 +253,6 @@ export default class TelegramBot extends BotClient {
 
   public async sendMessage(channel: Channel, messageText: string | Notification): Promise<boolean> {
     const permissions = await this.getUserPermissions(await this.getUser(), channel);
-    this.logger.debug(
-      `Permissions: W: ${permissions.canWrite} | E: ${permissions.canEdit} | P: ${permissions.canPin}`,
-    );
     // Check if the bot can write to this channel
     if (!permissions.canWrite) {
       if (this.removeData(channel)) {

--- a/src/bots/telegram.ts
+++ b/src/bots/telegram.ts
@@ -8,6 +8,7 @@ import Notification from '../notifications/notification';
 import MDRegex, { bold, seperator } from '../util/regex';
 import { StrUtil, mapAsync } from '../util/util';
 import Message from '../message';
+import Permissions from '../permissions';
 
 export default class TelegramBot extends BotClient {
   private static standardBot: TelegramBot;
@@ -86,6 +87,29 @@ export default class TelegramBot extends BotClient {
     }
     // the user is just a regular user
     return UserRole.USER;
+  }
+
+  public async getUserPermissions(user: User, channel: Channel): Promise<Permissions> {
+    let canWrite;
+    let canEdit;
+    let canPin;
+
+    try {
+      const chatMember = await this.bot.getChatMember(channel.id, user.id);
+
+      canWrite = chatMember.can_send_messages;
+      canEdit = chatMember.can_edit_messages;
+      canPin = chatMember.can_pin_messages;
+    } catch (error) {
+      this.logger.error(`Failed to get user permissions:\n${error}`);
+
+      canWrite = false;
+      canEdit = false;
+      canPin = false;
+    }
+
+    const permissions = new Permissions(true, canWrite, canEdit, canPin);
+    return permissions;
   }
 
   public async getChannelUserCount(channel: Channel): Promise<number> {

--- a/src/bots/telegram.ts
+++ b/src/bots/telegram.ts
@@ -198,6 +198,13 @@ export default class TelegramBot extends BotClient {
   }
 
   public async sendMessage(channel: Channel, messageText: string | Notification): Promise<boolean> {
+    // Check if the bot can write to this channel
+    if (!(await this.getUserPermissions(await this.getUser(), channel)).canWrite) {
+      if (this.removeData(channel)) {
+        this.logger.warn(`Can't write to channel, removing all data.`);
+      }
+      return false;
+    }
     let message = messageText;
     if (typeof message === 'string') {
       message = TelegramBot.msgFromMarkdown(message);

--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -1,6 +1,6 @@
 import EscapeRegex from 'escape-string-regexp';
 import BotClient from '../bots/bot';
-import User, { UserPermission } from '../user';
+import User, { UserRole } from '../user';
 import Channel from '../channel';
 import Message from '../message';
 
@@ -17,8 +17,8 @@ export default class Command {
   public callback: (bot: BotClient, message: Message, match: RegExpMatchArray) => void;
   /** Whether the command should use the bot prefix. */
   public hasPrefix: boolean;
-  /** The permission required to execute the command. */
-  public permission: UserPermission;
+  /** The role required to execute the command. */
+  public role: UserRole;
 
   /** Create a new command.
    *
@@ -27,7 +27,7 @@ export default class Command {
    * @param {string} triggerLabel - The label of the command trigger. Displayed in the help-command.
    * @param {string} trigger - The RegExp string triggering the command.
    * @param {Function} callback - The callback function executing the command.
-   * @param {UserPermission} permission - The permission required to execute the command.
+   * @param {UserRole} role - The role required to execute the command.
    * @param {boolean} hasPrefix - Whether the command should use the bot prefix. Default is true.
    */
   constructor(
@@ -36,7 +36,7 @@ export default class Command {
     triggerLabel: string,
     trigger: string,
     callback: (bot: BotClient, message: Message, match: RegExpMatchArray) => void,
-    permission?: UserPermission,
+    role?: UserRole,
     hasPrefix?: boolean,
   ) {
     this.label = label;
@@ -44,7 +44,7 @@ export default class Command {
     this.triggerLabel = triggerLabel;
     this.trigger = trigger;
     this.callback = callback;
-    this.permission = permission != null ? permission : UserPermission.USER;
+    this.role = role != null ? role : UserRole.USER;
     this.hasPrefix = hasPrefix != null ? hasPrefix : true;
   }
   /** Tries to execute the command on the given channel.
@@ -59,17 +59,17 @@ export default class Command {
     message: Message,
     match: RegExpMatchArray,
   ): Promise<boolean> {
-    // Check if the user has the required permission to execute the command.
-    if (await message.user.hasPermission(message.channel, this.permission)) {
+    // Check if the user has the required role to execute the command.
+    if (await message.user.hasRole(message.channel, this.role)) {
       this.callback(bot, message, match);
       const time = Date.now() - message.timestamp.valueOf();
       bot.logger.debug(`Command '${this.label}' executed in ${time} ms.`);
       return true;
     }
-    bot.logger.debug(`Command: ${this.label}: Insufficient permissions.`);
+    bot.logger.debug(`Command: ${this.label}: ${this.role} role required.`);
     bot.sendMessage(
       message.channel,
-      `You need the permission '${this.permission}' on this server to execute this command!`,
+      `You need the role '${this.role}' on this server to execute this command!`,
     );
     return false;
   }

--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -14,7 +14,7 @@ export default class Command {
   /** The RegExp string triggering the command. */
   public trigger: string;
   /** The callback function executing the command. */
-  public callback: (bot: BotClient, message: Message, match: RegExpMatchArray) => void;
+  public callback: (bot: BotClient, message: Message, match: RegExpMatchArray) => Promise<void>;
   /** Whether the command should use the bot prefix. */
   public hasPrefix: boolean;
   /** The role required to execute the command. */
@@ -35,7 +35,7 @@ export default class Command {
     description: string,
     triggerLabel: string,
     trigger: string,
-    callback: (bot: BotClient, message: Message, match: RegExpMatchArray) => void,
+    callback: (bot: BotClient, message: Message, match: RegExpMatchArray) => Promise<void>,
     role?: UserRole,
     hasPrefix?: boolean,
   ) {
@@ -61,7 +61,7 @@ export default class Command {
   ): Promise<boolean> {
     // Check if the user has the required role to execute the command.
     if (await message.user.hasRole(message.channel, this.role)) {
-      this.callback(bot, message, match);
+      await this.callback(bot, message, match);
       const time = Date.now() - message.timestamp.valueOf();
       bot.logger.debug(`Command '${this.label}' executed in ${time} ms.`);
       return true;

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -3,10 +3,8 @@ import getBots from '../bots/bots';
 import Command from './command';
 import DataManager from '../managers/data_manager';
 import Game from '../game';
-import botLogger from '../logger';
 import { filterAsync, mapAsync, naturalJoin, StrUtil } from '../util/util';
 import ProjectManager from '../managers/project_manager';
-import { Util, User } from 'discord.js';
 
 // Start
 const startCmd = new Command(
@@ -14,7 +12,7 @@ const startCmd = new Command(
   'Get started with the GameFeeder.',
   'start',
   'start',
-  (bot, message, _) => {
+  async (bot, message, _) => {
     const name = ProjectManager.getName();
     const gitLink = ProjectManager.getURL();
     const version = ProjectManager.getVersionNumber();
@@ -56,7 +54,7 @@ const aboutCmd = new Command(
   'Display info about the bot.',
   'about',
   '(about)|(info)\\s*$',
-  (bot, message, _) => {
+  async (bot, message, _) => {
     const name = ProjectManager.getName();
     const gitLink = ProjectManager.getURL();
     const version = ProjectManager.getVersionNumber();
@@ -73,7 +71,7 @@ const settingsCmd = new Command(
   'Display an overview of the settings you can configure for the bot.',
   'settings',
   '(settings)|(options)|(config)\\s*$',
-  (bot, message, _) => {
+  async (bot, message, _) => {
     const channel = message.channel;
     const gameStr =
       channel.gameSubs && channel.gameSubs.length > 0
@@ -99,7 +97,7 @@ const gamesCmd = new Command(
   'Display all available games.',
   'games',
   'games\\s*$',
-  (bot, message, _) => {
+  async (bot, message, _) => {
     const gamesList = Game.getGames().map((game) => `- ${game.label}`);
     const gamesMD = `Available games:\n${gamesList.join('\n')}`;
 
@@ -186,7 +184,7 @@ const unsubCmd = new Command(
   `Unsubscribe from the given game's feed`,
   'unsubscribe <game name>',
   'unsub(scribe)?(?<alias>.*)',
-  (bot, message, match: any) => {
+  async (bot, message, match: any) => {
     const channel = message.channel;
     let { alias } = match.groups;
     alias = alias ? alias.trim() : '';
@@ -287,7 +285,7 @@ const prefixCmd = new Command(
       if (bot.removeData(channel)) {
         bot.logger.warn(`Can't write to channel, removing all data.`);
       }
-      return false;
+      return;
     }
 
     bot.sendMessage(channel, `Changing the bot's prefix on this channel to \`${newPrefix}\`.`);
@@ -339,7 +337,7 @@ const notifyAllCmd = new Command(
   'Notify all subscribed users.',
   'notifyAll <message>',
   '(notifyAll(Subs)?)\\s*(?<msg>(?:.|\\s)*)$',
-  (bot, message, match: any) => {
+  async (bot, message, match: any) => {
     const channel = message.channel;
     let { msg } = match.groups;
     msg = msg ? msg.trim() : '';
@@ -370,7 +368,7 @@ const notifyGameSubsCmd = new Command(
   'Notify all subs of a game.',
   'notifyGameSubs (<game name>) <message>',
   '(notify(Game)?Subs)\\s*(\\((?<alias>.*)\\))?\\s*(?<msg>(?:.|\\s)*)\\s*$',
-  (bot, message, match: any) => {
+  async (bot, message, match: any) => {
     const channel = message.channel;
     let { alias, msg } = match.groups;
     alias = alias ? alias.trim() : '';
@@ -424,7 +422,7 @@ const flipCmd = new Command(
   'Flip a coin.',
   'flip',
   'flip',
-  (bot, message, _) => {
+  async (bot, message, _) => {
     const rnd = Math.random();
 
     let result;
@@ -447,7 +445,7 @@ const rollCmd = new Command(
   'Roll some dice.',
   'roll <dice count> <dice type> <modifier>',
   'r(?:oll)?\\s*(?:(?<diceCountStr>\\d+)\\s*)?d(?<diceTypeStr>\\d+)(?:\\s*(?<modifierStr>(?:\\+|-)\\d+))?',
-  (bot, message, match) => {
+  async (bot, message, match) => {
     const { diceCountStr, diceTypeStr, modifierStr } = match.groups;
 
     let diceCount = diceCountStr ? parseInt(diceCountStr, 10) : 1;
@@ -566,7 +564,7 @@ const pingCmd = new Command(
   'Test the delay of the bot.',
   'ping',
   'ping',
-  (bot, message, _) => {
+  async (bot, message, _) => {
     const time = Date.now() - message.timestamp.valueOf();
     bot.sendMessage(message.channel, `Pong! (${time} ms)`);
   },
@@ -579,7 +577,7 @@ const telegramCmdsCmd = new Command(
   'Get the string to properly register the commands on Telegram.',
   'telegramCmds',
   'telegramCmds?',
-  (bot, message, _) => {
+  async (bot, message, _) => {
     const cmds = commands.filter((command) => {
       // Filter out owner commands
       return command.role !== UserRole.OWNER;

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -259,7 +259,7 @@ const prefixCmd = new Command(
   `Change the bot's prefix used in this channel.`,
   'prefix',
   'prefix(?<newPrefix>.*)$',
-  (bot, message, match: any) => {
+  async (bot, message, match: any) => {
     const channel = message.channel;
     let { newPrefix } = match.groups;
     newPrefix = newPrefix ? newPrefix.trim() : '';
@@ -279,6 +279,15 @@ const prefixCmd = new Command(
     // Check if the user wants to reset the prefix
     if (newPrefix === 'reset') {
       newPrefix = bot.prefix;
+    }
+
+    // Check if the bot can write to this channel
+    const permissions = await bot.getUserPermissions(await bot.getUser(), channel);
+    if (!permissions.canWrite) {
+      if (bot.removeData(channel)) {
+        bot.logger.warn(`Can't write to channel, removing all data.`);
+      }
+      return false;
     }
 
     bot.sendMessage(channel, `Changing the bot's prefix on this channel to \`${newPrefix}\`.`);

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -519,8 +519,6 @@ const statsCmd = new Command(
 
     // User and channel count
     for (const bot of bots) {
-      // Clean up dead channels
-      await bot.removeChannelsWithoutWritePermissions();
       // Get statistics
       const channelCount = await bot.getChannelCount();
       const userCount = await bot.getUserCount();

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -1,4 +1,4 @@
-import { UserPermission } from '../user';
+import { UserRole } from '../user';
 import getBots from '../bots/bots';
 import Command from './command';
 import DataManager from '../managers/data_manager';
@@ -34,10 +34,10 @@ const helpCmd = new Command(
   'help',
   'help\\s*$',
   async (bot, message, _) => {
-    // Only show the commands the user has permission to execute.
+    // Only show the commands the user has the role to execute.
     const filteredCommands = await filterAsync(
       commands,
-      async (command) => await message.user.hasPermission(message.channel, command.permission),
+      async (command) => await message.user.hasRole(message.channel, command.role),
     );
     const commandsList = filteredCommands.map(
       (command) =>
@@ -177,7 +177,7 @@ const subCmd = new Command(
 
     bot.sendMessage(channel, msg);
   },
-  UserPermission.ADMIN,
+  UserRole.ADMIN,
 );
 
 // Unsubscribe
@@ -250,7 +250,7 @@ const unsubCmd = new Command(
 
     bot.sendMessage(channel, msg);
   },
-  UserPermission.ADMIN,
+  UserRole.ADMIN,
 );
 
 // Prefix
@@ -321,7 +321,7 @@ const prefixCmd = new Command(
     DataManager.setSubscriberData(subscribers);
     return;
   },
-  UserPermission.ADMIN,
+  UserRole.ADMIN,
 );
 
 // Notify All
@@ -352,7 +352,7 @@ const notifyAllCmd = new Command(
       curBot.sendMessageToAllSubs(msg);
     }
   },
-  UserPermission.OWNER,
+  UserRole.OWNER,
 );
 
 // Notify Game Subs
@@ -406,7 +406,7 @@ const notifyGameSubsCmd = new Command(
         `Use \`${gamesCmd.getTriggerLabel(channel)}\` to view a list of all available games.`,
     );
   },
-  UserPermission.OWNER,
+  UserRole.OWNER,
 );
 
 // Flip
@@ -429,7 +429,7 @@ const flipCmd = new Command(
     // Notify the user
     bot.sendMessage(message.channel, `Flipping a coin: **${result}**`);
   },
-  UserPermission.USER,
+  UserRole.USER,
 );
 
 // Roll
@@ -493,7 +493,7 @@ const rollCmd = new Command(
     // Notify user
     bot.sendMessage(message.channel, `${text}:\n${resultStr}`);
   },
-  UserPermission.USER,
+  UserRole.USER,
 );
 
 // Stats
@@ -545,7 +545,7 @@ const statsCmd = new Command(
 
     bot.sendMessage(message.channel, statString);
   },
-  UserPermission.USER,
+  UserRole.USER,
 );
 
 // Ping
@@ -558,7 +558,7 @@ const pingCmd = new Command(
     const time = Date.now() - message.timestamp.valueOf();
     bot.sendMessage(message.channel, `Pong! (${time} ms)`);
   },
-  UserPermission.USER,
+  UserRole.USER,
 );
 
 // Telegram Cmds
@@ -570,7 +570,7 @@ const telegramCmdsCmd = new Command(
   (bot, message, _) => {
     const cmds = commands.filter((command) => {
       // Filter out owner commands
-      return command.permission !== UserPermission.OWNER;
+      return command.role !== UserRole.OWNER;
     });
     const cmdEntries = cmds.map((cmd) => {
       return `${cmd.label} - ${cmd.description}`;
@@ -580,7 +580,7 @@ const telegramCmdsCmd = new Command(
 
     bot.sendMessage(message.channel, telegramCmdStr);
   },
-  UserPermission.OWNER,
+  UserRole.OWNER,
 );
 
 // Debug
@@ -591,7 +591,7 @@ const debugCmd = new Command(
   'debug',
   async (bot, message, _) => {
     // Aggregate debug info
-    const userPermission = await message.user.getPermission(message.channel);
+    const userRole = await message.user.getRole(message.channel);
     const userID = message.user.id;
     const channelID = message.channel.id;
     const serverMembers = await bot.getChannelUserCount(message.channel);
@@ -599,7 +599,7 @@ const debugCmd = new Command(
     const time = Date.now() - message.timestamp.valueOf();
 
     const debugStr =
-      `**User info:**\n- ID: ${userID}\n- Permission: ${userPermission}\n` +
+      `**User info:**\n- ID: ${userID}\n- Role: ${userRole}\n` +
       `**Channel info:**\n-ID: ${channelID}\n- Server members: ${serverMembers}\n` +
       `**Bot info:**\n- Tag: ${botTag}\n- Delay: ${time} ms`;
 

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -113,7 +113,7 @@ const subCmd = new Command(
   `Subscribe to the given game's feed.`,
   'subscribe <game name>',
   'sub(scribe)?(?<alias>.*)',
-  (bot, message, match: any) => {
+  async (bot, message, match: any) => {
     const channel = message.channel;
     let alias: string = match.groups.alias;
     alias = alias ? alias.trim() : '';
@@ -148,8 +148,8 @@ const subCmd = new Command(
     invalidAliases = [...new Set(invalidAliases)];
 
     // The map of which game is a new sub
-    const gameMap = aliasGames.map((game) => {
-      const isNew = bot.addSubscriber(channel, game);
+    const gameMap = await mapAsync(aliasGames, async (game) => {
+      const isNew = await bot.addSubscriber(channel, game);
       return { game, isNew };
     });
 

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -520,9 +520,12 @@ const statsCmd = new Command(
     const bots = getBots();
 
     // User and channel count
-    for (const curBot of bots) {
-      const channelCount = await curBot.getChannelCount();
-      const userCount = await curBot.getUserCount();
+    for (const bot of bots) {
+      // Clean up dead channels
+      await bot.removeChannelsWithoutWritePermissions();
+      // Get statistics
+      const channelCount = await bot.getChannelCount();
+      const userCount = await bot.getUserCount();
 
       totalUserCount += userCount;
       totalChannelCount += channelCount;
@@ -530,7 +533,7 @@ const statsCmd = new Command(
       const userString = userCount > 1 ? 'users' : 'user';
       const channelString = channelCount > 1 ? 'servers' : 'server';
       botStatStrings.push(
-        `     ${curBot.label}: ${userCount} ${userString} in ${channelCount} ${channelString}.`,
+        `     ${bot.label}: ${userCount} ${userString} in ${channelCount} ${channelString}.`,
       );
     }
 

--- a/src/notifications/notification.ts
+++ b/src/notifications/notification.ts
@@ -1,6 +1,7 @@
 import Game from '../game';
 import NotificationElement from './notification_element';
 import Comparable from '../util/comparable';
+import { StrUtil } from '../util/util';
 
 /** A representation of a bot notification. */
 export default class Notification implements Comparable<Notification> {
@@ -137,19 +138,27 @@ export default class Notification implements Comparable<Notification> {
     return 0;
   }
 
-  public toMDString(): string {
+  public toMDString(limit?: number): string {
     const titleText = this.title.link
       ? `[**${this.title.text}**](${this.title.link})`
       : this.title.text;
+
+    let mdStr;
 
     if (this.author.text) {
       const authorText = this.author.link
         ? `[${this.author.text}](${this.author.link})`
         : this.author.text;
 
-      return `New **${this.game.label}** update - ${authorText}:\n\n${titleText}\n\n${this.content}`;
+      const contentText = this.content ? `\n\n${this.content}` : '';
+      mdStr = `New **${this.game.label}** update - ${authorText}:\n\n${titleText}${contentText}`;
+    } else {
+      const contentText = this.content ? `\n\n${this.content}` : '';
+      mdStr = `New **${this.game.label}** update:\n\n${titleText}${contentText}`;
     }
 
-    return `New **${this.game.label}** update:\n\n${titleText}\n\n${this.content}`;
+    mdStr = StrUtil.naturalLimit(mdStr, limit);
+
+    return mdStr;
   }
 }

--- a/src/notifications/notification.ts
+++ b/src/notifications/notification.ts
@@ -145,17 +145,14 @@ export default class Notification implements Comparable<Notification> {
 
     let mdStr;
 
-    if (this.author.text) {
-      const authorText = this.author.link
-        ? `[${this.author.text}](${this.author.link})`
-        : this.author.text;
+    const authorText = this.author.text
+      ? this.author.link
+        ? ` - [${this.author.text}](${this.author.link})`
+        : this.author.text
+      : '';
 
-      const contentText = this.content ? `\n\n${this.content}` : '';
-      mdStr = `New **${this.game.label}** update - ${authorText}:\n\n${titleText}${contentText}`;
-    } else {
-      const contentText = this.content ? `\n\n${this.content}` : '';
-      mdStr = `New **${this.game.label}** update:\n\n${titleText}${contentText}`;
-    }
+    const contentText = this.content ? `\n\n${this.content}` : '';
+    mdStr = `New **${this.game.label}** update${authorText}:\n\n${titleText}${contentText}`;
 
     mdStr = StrUtil.naturalLimit(mdStr, limit);
 

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -1,0 +1,25 @@
+/** Represents the permissions a user has on a channel. */
+export default class Permissions {
+  /** Indicates if the bot has access to a channel. */
+  public hasChannelAccess: boolean;
+  /** Indicates if the bot can write on a channel. */
+  public canWrite: boolean;
+  /** Indicates if the bot can edit messages on a channel. */
+  public canEdit: boolean;
+  /** Indicates if the bot can pin messages on a channel. */
+  public canPin: boolean;
+
+  /** Creates new permissions.
+   *
+   * @param hasChannelAccess - Indicates if the bot has access to a channel.
+   * @param canWrite -  Indicates if the bot can write on a channel.
+   * @param canEdit - Indicates if the bot can edit messages on a channel.
+   * @param canPin - Indicates if the bot can pin messages on a channel.
+   */
+  constructor(hasChannelAccess: boolean, canWrite: boolean, canEdit: boolean, canPin: boolean) {
+    this.hasChannelAccess = hasChannelAccess;
+    this.canWrite = canWrite;
+    this.canEdit = canEdit;
+    this.canPin = canPin;
+  }
+}

--- a/src/reddit/reddit_user.ts
+++ b/src/reddit/reddit_user.ts
@@ -9,14 +9,8 @@ export default class RedditUserProvider {
     this.name = name;
     if (typeof titleFilter === 'string' || titleFilter instanceof String) {
       this.titleFilter = new RegExp(titleFilter);
-      RedditUserProvider.logger.debug(
-        `Regex filter created from '${titleFilter}' for ${this.name}`,
-      );
     } else if (titleFilter instanceof RegExp) {
       this.titleFilter = titleFilter;
-      RedditUserProvider.logger.debug(
-        `Filter '${titleFilter}' is already a regex for ${this.name}`,
-      );
     } else {
       this.titleFilter = /.*/;
       RedditUserProvider.logger.warn(

--- a/src/user.ts
+++ b/src/user.ts
@@ -17,38 +17,38 @@ export default class User {
     this.bot = bot;
     this.id = id;
   }
-  /** Get's the user's permission on the given channel.
+  /** Get's the user's rpöe on the given channel.
    *
-   * @param channel - The channel to get the permissions on.
-   * @returns The permission the user has on the given channel.
+   * @param channel - The channel to get the role on.
+   * @returns The role the user has on the given channel.
    */
-  public async getPermission(channel: Channel): Promise<UserPermission> {
-    return await this.bot.getUserPermission(this, channel);
+  public async getRole(channel: Channel): Promise<UserRole> {
+    return await this.bot.getUserRole(this, channel);
   }
-  /** Determines whether the user has the given permission on the given channel.
+  /** Determines whether the user has the given role on the given channel.
    *
-   * @param channel - The channel the user wants the permission on.
-   * @param permission - The permission the user should have.
+   * @param channel - The channel the user wants the role on.
+   * @param role - The role the user should have.
    *
-   * @returns True, if the user has the given permission on the given channel, else false.
+   * @returns True, if the user has the given role on the given channel, else false.
    */
-  public async hasPermission(channel: Channel, permission: UserPermission): Promise<boolean> {
-    switch (permission) {
-      case UserPermission.OWNER:
-        return (await this.getPermission(channel)) === UserPermission.OWNER;
-      case UserPermission.ADMIN:
-        return (await this.getPermission(channel)) !== UserPermission.USER;
-      case UserPermission.USER:
+  public async hasRole(channel: Channel, role: UserRole): Promise<boolean> {
+    switch (role) {
+      case UserRole.OWNER:
+        return (await this.getRole(channel)) === UserRole.OWNER;
+      case UserRole.ADMIN:
+        return (await this.getRole(channel)) !== UserRole.USER;
+      case UserRole.USER:
         return true;
       default:
-        User.logger.debug('Unknown UserPermission. Denying access.');
+        User.logger.debug('Unknown UserRole. Denying access.');
         return false;
     }
   }
 }
 
-/** Determines the permission a user has on a channel. */
-export enum UserPermission {
+/** Determines the role a user has on a channel. */
+export enum UserRole {
   /** The user is just a normal user. */
   USER = 'User',
   /** The user has admin priviliges. */

--- a/src/user.ts
+++ b/src/user.ts
@@ -17,7 +17,7 @@ export default class User {
     this.bot = bot;
     this.id = id;
   }
-  /** Get's the user's rpöe on the given channel.
+  /** Get's the user's role on the given channel.
    *
    * @param channel - The channel to get the role on.
    * @returns The role the user has on the given channel.


### PR DESCRIPTION
**Description**:
Handles being missing permissions or access:
- Remove channel data when being removed from a channel (except from a Telegram channel group, not handled by their events)
- Check for writing permissions before sending messages, subscribing and changing the prefix
- Clean up dead channels on startup and before using the `stats` command

Also fixes some issues with async commands and their time measurements.
Closes #43.

**Checklist**:

- [x] Tested the bot on both clients with a few commands
- [x] Updated the [`README`](README.md) if necessary
- [x] Updated the version string in the [`package.json`](package.json) if necessary
