### PR TITLE
Fix Dota /u/TheZett filter

### DIFF
--- a/config/games/dota.json
+++ b/config/games/dota.json
@@ -26,7 +26,7 @@
           },
           {
             "name": "TheZett",
-            "titleFilter": "Update"
+            "titleFilter": "Dota 2 Update"
           }
         ]
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gamefeeder",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "A notification bot for several games, available on Discord and Telegram.",
   "main": "src/_main.ts",
   "repository": {


### PR DESCRIPTION
**Description**:
Change the Dota filter of /u/TheZett from `Update` to `Dota 2 Update` per the provider's request.

**Checklist**:

- [x] Tested the bot on both clients with a few commands
- [x] Updated the [`README`](README.md) if necessary
- [x] Updated the version string in the [`package.json`](package.json) if necessary
