### PR TITLE
206 Fix telegram notifications

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -56,24 +56,25 @@ So far, we are providing the following commands:
 - The default prefix on Discord is `!`.
 - You can also use the bot's tag as prefix.
 
-| Command                                    | Role  | Summary                                                                         |
-| ------------------------------------------ | ----- | ------------------------------------------------------------------------------- |
-| `start`                                    | User  | Get started with the GameFeeder.                                                |
-| `help`                                     | User  | Display all available commands.                                                 |
-| `about`                                    | User  | Display information about this bot.                                             |
-| `settings`                                 | User  | Display an overview of the settings you can configure for the bot.              |
-| `games`                                    | User  | Display a list of all available games.                                          |
-| `stats`                                    | User  | Display some stats about the bot.                                               |
-| `ping`                                     | User  | Test the delay of the bot.                                                      |
-| `debug`                                    | User  | Display useful debug information.                                               |
-| `flip`                                     | User  | Flip a coin.                                                                    |
-| `roll <dice count> <dice type> <modifier>` | User  | Roll some dice.                                                                 |
-| `subscribe <game name>`                    | Admin | Subscribe to a game's feed.                                                     |
-| `unsubscribe <game name>`                  | Admin | Unsubscribe from a game's feed.                                                 |
-| `prefix <new prefix>`                      | Admin | Change the prefix the bot uses on this channel.                                 |
-| `notifyAll <message>`                      | Owner | Send a message to all subscribers.                                              |
-| `notifyGameSubs (<game name>) <message>`   | Owner | Send a message to all subscribers of a game.                                    |
-| `telegramCmds`                             | Owner | Simplifies the command registration on Telegram by printing the command string. |
+| Command                                         | Role  | Summary                                                                         |
+| ----------------------------------------------- | ----- | ------------------------------------------------------------------------------- |
+| `start`                                         | User  | Get started with the GameFeeder.                                                |
+| `help`                                          | User  | Display all available commands.                                                 |
+| `about`                                         | User  | Display information about this bot.                                             |
+| `settings`                                      | User  | Display an overview of the settings you can configure for the bot.              |
+| `games`                                         | User  | Display a list of all available games.                                          |
+| `stats`                                         | User  | Display some stats about the bot.                                               |
+| `ping`                                          | User  | Test the delay of the bot.                                                      |
+| `debug`                                         | User  | Display useful debug information.                                               |
+| `flip`                                          | User  | Flip a coin.                                                                    |
+| `roll <dice count> <dice type> <modifier>`      | User  | Roll some dice.                                                                 |
+| `subscribe <game name>`                         | Admin | Subscribe to a game's feed.                                                     |
+| `unsubscribe <game name>`                       | Admin | Unsubscribe from a game's feed.                                                 |
+| `prefix <new prefix>`                           | Admin | Change the prefix the bot uses on this channel.                                 |
+| `notifyAll <message>`                           | Owner | Send a message to all subscribers.                                              |
+| `notifyGameSubs (<game name>) <message>`        | Owner | Send a message to all subscribers of a game.                                    |
+| `telegramCmds`                                  | Owner | Simplifies the command registration on Telegram by printing the command string. |
+| `label <bot name> <channel id> <channel label>` | Owner | Set a label for the channel to simplify debugging.                              |
 
 **Note:** The messages in the notification commands should be provided in the raw markdown format, they will be reformatted for the different clients. Discord should be used for these commands, as some formatting information gets lost in Telegram (when Telegram uses the same format).
 
@@ -94,7 +95,7 @@ So far, we are supporting the following games:
   - Posts on the [CS:GO blog](https://blog.counter-strike.net/)
 - <strong align="left">Dota 2</strong> <img src="http://cdn.dota2.com/apps/dota2/images/reborn/day1/Dota2OrangeLogo.png" height="17px"/>
   - Reddit posts by [/u/Kappa_Man](https://www.reddit.com/user/Kappa_Man/posts/), [/u/TheZett](https://www.reddit.com/user/TheZett/posts/) and [/u/wykrhm](https://www.reddit.com/user/wykrhm/posts/) on [/r/DotA2](https://www.reddit.com/r/DotA2/)
-  - Reddit posts by [/u/Kappa_Man](https://www.reddit.com/user/Kappa_Man/posts/), [/u/Magesunite](https://www.reddit.com/user/Magesunite/posts/) and [/u/MSTRMN_](https://www.reddit.com/user/MSTRMN_/posts/) on [/r/DotaPatches](https://www.reddit.com/r/DotaPatches/)
+  - Reddit posts by [/u/Kappa_Man](https://www.reddit.com/user/Kappa_Man/posts/), [/u/Magesunite](https://www.reddit.com/user/Magesunite/posts/) and [/u/MSTRMN\_](https://www.reddit.com/user/MSTRMN_/posts/) on [/r/DotaPatches](https://www.reddit.com/r/DotaPatches/)
   - Gamplay updates on the [Dota 2 patch page](https://www.dota2.com/patches)
   - Blog posts on the [Dota 2 Blog](http://blog.dota2.com/?l=english)
 - <strong align="left">Factorio</strong> <img src="https://wiki.factorio.com/images/Factorio-icon.png" height="17px"/>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gamefeeder",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "A notification bot for several games, available on Discord and Telegram.",
   "main": "src/_main.ts",
   "repository": {

--- a/src/bots/bot.ts
+++ b/src/bots/bot.ts
@@ -159,7 +159,7 @@ export default abstract class BotClient {
       sub.gameSubs = sub.gameSubs.filter((gameName: string) => gameName !== game.name);
 
       // Remove unnecessary entries
-      if (sub.gameSubs.length === 0 && !sub.prefix) {
+      if (sub.gameSubs.length === 0 && !sub.prefix && !sub.label) {
         this.logger.debug(`Removing unnecessary entry for channel ${channel.getLabel()}...`);
         subs.splice(existingSubId, 1);
       } else {

--- a/src/bots/bot.ts
+++ b/src/bots/bot.ts
@@ -133,7 +133,7 @@ export default abstract class BotClient {
     channels.push({
       gameSubs: [game.name],
       id: channel.id,
-      prefix: '',
+      prefix: undefined,
     });
     // Save the changes
     subscribers[this.name] = channels;

--- a/src/bots/bot.ts
+++ b/src/bots/bot.ts
@@ -103,7 +103,7 @@ export default abstract class BotClient {
     const permissions = await this.getUserPermissions(await this.getUser(), channel);
     if (!permissions.canWrite) {
       if (this.removeData(channel)) {
-        this.logger.warn(`Can't write to channel, removing all data.`);
+        this.logger.warn(`Can't write to channel ${channel.getLabel()}, removing all data.`);
       }
       return false;
     }
@@ -160,7 +160,7 @@ export default abstract class BotClient {
 
       // Remove unnecessary entries
       if (sub.gameSubs.length === 0 && !sub.prefix) {
-        this.logger.debug('Removing unnecessary channel entry...');
+        this.logger.debug(`Removing unnecessary entry for channel ${channel.getLabel()}...`);
         subs.splice(existingSubId, 1);
       } else {
         subs[existingSubId] = sub;
@@ -266,6 +266,7 @@ export default abstract class BotClient {
           return Game.getGameByName(gameName);
         });
         channel.prefix = sub.prefix;
+        channel.label = sub.label;
         break;
       }
     }

--- a/src/bots/discord.ts
+++ b/src/bots/discord.ts
@@ -169,12 +169,16 @@ export default class DiscordBot extends BotClient {
 
         return new Permissions(hasAccess, canWrite, canEdit, canPin);
       } catch (error) {
-        this.logger.error(`Failed to get permissions for text channel:\n${error}`);
+        this.logger.error(
+          `Failed to get permissions for text channel ${channel.getLabel()}:\n${error}`,
+        );
         throw error;
       }
     }
 
-    this.logger.error(`Unecpected Discord channel type: ${discordChannel}`);
+    this.logger.error(
+      `Unecpected Discord channel type for channel ${channel.getLabel()}: ${discordChannel}`,
+    );
     return new Permissions(false, false, false, false);
   }
 
@@ -196,7 +200,7 @@ export default class DiscordBot extends BotClient {
       const discordUser = discordChannel.members.get(user.id);
       canEmbed = discordChannel.permissionsFor(discordUser).has('EMBED_LINKS');
     } else {
-      this.logger.error(`Unecpected Discord channel type.`);
+      this.logger.error(`Unecpected Discord channel type for channel ${channel.getLabel()}.`);
       canEmbed = false;
     }
 
@@ -288,12 +292,14 @@ export default class DiscordBot extends BotClient {
       const permissions = await this.getUserPermissions(await this.getUser(), channel);
       if (!permissions.canWrite) {
         if (this.removeData(channel)) {
-          this.logger.warn(`Can't write to channel, removing all data.`);
+          this.logger.warn(`Can't write to channel ${channel.getLabel()}, removing all data.`);
         }
         return false;
       }
     } catch (error) {
-      this.logger.error(`Failed to get user permissions while sending to channel:\n${error}`);
+      this.logger.error(
+        `Failed to get user permissions while sending to channel ${channel.getLabel()}:\n${error}`,
+      );
       return false;
     }
 
@@ -303,7 +309,7 @@ export default class DiscordBot extends BotClient {
       try {
         return await this.sendToChannel(channel, messageText);
       } catch (error) {
-        this.logger.error(`Failed to send message:\n${error}`);
+        this.logger.error(`Failed to send message to channel ${channel.getLabel()}:\n${error}`);
         return false;
       }
     }
@@ -315,7 +321,7 @@ export default class DiscordBot extends BotClient {
       try {
         return await this.sendToChannel(channel, '', embed);
       } catch (error) {
-        this.logger.error(`Failed to send message:\n${error}`);
+        this.logger.error(`Failed to send message to channel ${channel.getLabel()}:\n${error}`);
         return false;
       }
     }
@@ -325,7 +331,7 @@ export default class DiscordBot extends BotClient {
     try {
       return await this.sendToChannel(channel, messageText);
     } catch (error) {
-      this.logger.error(`Failed to send message:\n${error}`);
+      this.logger.error(`Failed to send message to channel ${channel.getLabel()}:\n${error}`);
       return false;
     }
   }
@@ -474,7 +480,7 @@ export default class DiscordBot extends BotClient {
     try {
       discordChannel = botChannels.get(channel.id);
     } catch (error) {
-      this.logger.error(`Failed to get discord channel:\n${error}`);
+      this.logger.error(`Failed to get discord channel ${channel.getLabel()}:\n${error}`);
       return false;
     }
 
@@ -490,7 +496,7 @@ export default class DiscordBot extends BotClient {
       } else {
         errorMsg = error.toString();
       }
-      this.logger.error(`Failed to send message to channel:\n${errorMsg}`);
+      this.logger.error(`Failed to send message to channel ${channel.getLabel()}:\n${errorMsg}`);
       return false;
     };
 
@@ -508,7 +514,7 @@ export default class DiscordBot extends BotClient {
         return true;
       }
     } catch (error) {
-      this.logger.error(`Failed to send message to channel:\n${error}`);
+      this.logger.error(`Failed to send message to channel ${channel.getLabel()}:\n${error}`);
     }
     return false;
   }

--- a/src/bots/telegram.ts
+++ b/src/bots/telegram.ts
@@ -268,20 +268,6 @@ export default class TelegramBot extends BotClient {
   }
 
   public async sendMessage(channel: Channel, messageText: string | Notification): Promise<boolean> {
-    try {
-      const permissions = await this.getUserPermissions(await this.getUser(), channel);
-      // Check if the bot can write to this channel
-      if (!permissions.canWrite) {
-        if (this.removeData(channel)) {
-          this.logger.warn(`Can't write to channel, removing all data.`);
-        }
-        return false;
-      }
-    } catch (error) {
-      this.logger.error(`Failed to get user permissions while sending to channel:\n${error}`);
-      return false;
-    }
-
     let message = messageText;
     if (typeof message === 'string') {
       message = TelegramBot.msgFromMarkdown(message);

--- a/src/bots/telegram.ts
+++ b/src/bots/telegram.ts
@@ -88,7 +88,7 @@ export default class TelegramBot extends BotClient {
         return UserRole.ADMIN;
       }
     } catch (error) {
-      this.logger.error(`Failed to get chat admins:\n${error}`);
+      this.logger.error(`Failed to get chat admins on channel ${channel.getLabel()}:\n${error}`);
     }
     // the user is just a regular user
     return UserRole.USER;
@@ -113,7 +113,9 @@ export default class TelegramBot extends BotClient {
               throw error;
           }
         }
-        this.logger.error(`Failed to get chat to check permissions:\n${error}`);
+        this.logger.error(
+          `Failed to get chat to check permissions on channel ${channel.getLabel()}:\n${error}`,
+        );
         throw error;
       });
       // Check for expected chat errors
@@ -122,7 +124,7 @@ export default class TelegramBot extends BotClient {
       }
       // Try to get chat member
       const chatMember = await this.bot.getChatMember(channel.id, user.id).catch((error) => {
-        this.logger.error(`Failed to get chat member:\n${error}`);
+        this.logger.error(`Failed to get chat member on channel ${channel.getLabel()}:\n${error}`);
         throw error;
       });
       // Check for expected chat member errors
@@ -153,7 +155,9 @@ export default class TelegramBot extends BotClient {
             : true
           : false);
     } catch (error) {
-      this.logger.error(`Failed to get user permissions due to unexpected error:\n${error}`);
+      this.logger.error(
+        `Failed to get user permissions due to unexpected error on channel ${channel.getLabel()}:\n${error}`,
+      );
       throw error;
     }
 
@@ -166,7 +170,9 @@ export default class TelegramBot extends BotClient {
     try {
       return (await this.bot.getChatMembersCount(channel.id)) - 1;
     } catch (error) {
-      this.logger.error(`Failed to get chat member count for a channel:\n${error}`);
+      this.logger.error(
+        `Failed to get chat member count for channel ${channel.getLabel()}:\n${error}`,
+      );
       return 0;
     }
   }
@@ -195,8 +201,8 @@ export default class TelegramBot extends BotClient {
 
   /** Executes the given command if the message matches the regex. */
   private async onMessage(msg: TelegramAPI.Message, command: Command): Promise<void> {
+    const channel = this.getChannelByID(msg.chat.id.toString());
     try {
-      const channel = this.getChannelByID(msg.chat.id.toString());
       // Channel messages don't have an author, so we have to work around that
       const userID = msg.from ? msg.from.id.toString() : this.channelAuthorID;
       // FIX: Properly identify the user key
@@ -216,7 +222,9 @@ export default class TelegramBot extends BotClient {
         await command.execute(message, regMatch);
       }
     } catch (error) {
-      this.logger.error(`Failed to execute command ${command.name}:\n${error}`);
+      this.logger.error(
+        `Failed to execute command ${command.name} on channel ${channel.getLabel()}:\n${error}`,
+      );
     }
   }
 
@@ -334,24 +342,24 @@ export default class TelegramBot extends BotClient {
         // Chat not found
         case 400:
           this.logger.warn(
-            `Failed to send notification to channel, error code 400. Removing channel data.`,
+            `Failed to send notification to channel ${channel.getLabel()}, error code 400. Removing channel data.`,
           );
           this.removeData(channel);
           break;
         // Bot is not a member of the channel chat or blocked by user
         case 403:
           this.logger.warn(
-            `Failed to send notification to channel, error code 403. Removing channel data.`,
+            `Failed to send notification to channel ${channel.getLabel()}, error code 403. Removing channel data.`,
           );
           this.removeData(channel);
           break;
         default:
           this.logger.error(
-            `Failed to send notification to channel, error code ${errorCode}:\n${error}`,
+            `Failed to send notification to channel ${channel.getLabel()}, error code ${errorCode}:\n${error}`,
           );
       }
     } else {
-      this.logger.error(`Failed to send message to channel:\n${error}`);
+      this.logger.error(`Failed to send message to channel ${channel.getLabel()}:\n${error}`);
     }
   }
 

--- a/src/bots/telegram.ts
+++ b/src/bots/telegram.ts
@@ -276,6 +276,21 @@ export default class TelegramBot extends BotClient {
   }
 
   public async sendMessage(channel: Channel, messageText: string | Notification): Promise<boolean> {
+    // TODO: Fix permission check
+    // try {
+    //   const permissions = await this.getUserPermissions(await this.getUser(), channel);
+    //   // Check if the bot can write to this channel
+    //   if (!permissions.canWrite) {
+    //     if (this.removeData(channel)) {
+    //       this.logger.warn(`Can't write to channel, removing all data.`);
+    //     }
+    //     return false;
+    //   }
+    // } catch (error) {
+    //   this.logger.error(`Failed to get user permissions while sending to channel:\n${error}`);
+    //   return false;
+    // }
+
     let message = messageText;
     if (typeof message === 'string') {
       message = TelegramBot.msgFromMarkdown(message);

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -63,6 +63,7 @@ export default class Channel {
 
   /** Returns the label and id of the channel. */
   public getLabel(): string {
-    return this.label ? `${this.label} (${this.id})` : this.id;
+    const ID = `${this.bot.name.substr(0, 1).toLocaleUpperCase()}-${this.id}`;
+    return this.label ? `'${this.label}' (${ID})` : ID;
   }
 }

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -5,6 +5,8 @@ import Game from './game';
 export default class Channel {
   /** The unique ID of the channel. */
   public id: string;
+  /** The label of the channel (if specified). */
+  public label?: string;
   /** The BotClient this channel is used in. */
   public bot: BotClient;
   /** The games this channel is subscribed to. */
@@ -12,11 +14,12 @@ export default class Channel {
   /** The prefix the channel uses. */
   public prefix: string;
   /** Creates a new Channel. */
-  constructor(id: string, bot: BotClient, gameSubs?: Game[], prefix?: string) {
+  constructor(id: string, bot: BotClient, gameSubs?: Game[], prefix?: string, label?: string) {
     this.id = id;
     this.bot = bot;
     this.gameSubs = gameSubs || [];
-    this.prefix = prefix != null ? prefix : '';
+    this.prefix = prefix;
+    this.label = label;
   }
   /** Compares the channel to another channel.
    *
@@ -30,12 +33,13 @@ export default class Channel {
     return this.id === other.id;
   }
   public toJSON(): string {
+    const labelStr = this.label ? `, "label": "${this.label}"` : '';
+    const prefixStr = this.prefix ? `, "prefix": "${this.prefix}"` : '';
     return `{
-      "id": "${this.id}",
+      "id": "${this.id}"${labelStr},
       "gameSubs": [
         ${this.gameSubs.map((game) => game.name).join(', ')}
-      ],
-      "prefix": "${this.prefix}"
+      ]${prefixStr}
     }`;
   }
   /** Gets the prefix used in this channel
@@ -55,5 +59,10 @@ export default class Channel {
    */
   public async getUserCount(): Promise<number> {
     return this.bot.getChannelUserCount(this);
+  }
+
+  /** Returns the label and id of the channel. */
+  public getLabel(): string {
+    return this.label ? `${this.label} (${this.id})` : this.id;
   }
 }

--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -62,12 +62,16 @@ export default abstract class Command {
       await this.action(message, match);
       const time = Date.now() - message.timestamp.valueOf();
       if (!(this instanceof CommandGroup)) {
-        bot.logger.debug(`Command '${this.name}' executed in ${time} ms.`);
+        bot.logger.debug(
+          `Command '${this.name}' executed on channel ${message.channel.getLabel()} in ${time} ms.`,
+        );
       }
       return true;
     }
 
-    bot.logger.debug(`Command: ${this.name}: ${this.role} role required.`);
+    bot.logger.debug(
+      `Command ${this.name} on channel ${message.channel.getLabel()}: ${this.role} role required.`,
+    );
     bot.sendMessage(
       message.channel,
       `You need the role '${this.role}' on this server to execute this command!`,

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -307,7 +307,7 @@ const prefixCmd = new TwoPartCommand(
     const permissions = await bot.getUserPermissions(await bot.getUser(), channel);
     if (!permissions.canWrite) {
       if (bot.removeData(channel)) {
-        bot.logger.warn(`Can't write to channel, removing all data.`);
+        bot.logger.warn(`Can't write to channel ${channel.getLabel()}, removing all data.`);
       }
       return;
     }

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -685,6 +685,163 @@ const debugCmd = new SimpleAction(
   },
 );
 
+/** Label command, used to change the label of the given channel. */
+const labelCmd = new TwoPartCommand(
+  'label',
+  `Change the channel's label for easier debugging.`,
+  'label <bot name> <channel id> <channel label>',
+  // Group trigger
+  /^\s*label(?<group>.*)$/,
+  // Action trigger
+  /^\s*(?:(?<botName>\w+)\s+)?(?<channelID>(?:(?:\+|-)?\d+)|(?:this))\s+(?<channelLabel>.+?)\s*$/,
+  // Action
+  async (message, match) => {
+    const bot = message.getBot();
+    const { botName, channelID, channelLabel } = match.groups;
+
+    let channelBot = bot;
+    // Get the bot to find the channel on
+    if (botName) {
+      const findBot = getBots().find((client) => client.name === botName);
+
+      if (findBot) {
+        channelBot = findBot;
+      } else {
+        // Did not find the specified bot
+        const botList = getBots()
+          .map((client) => `- ${client.name}`)
+          .join('\n');
+
+        message.reply(
+          `'${botName}' is not an available bot! Try one of the following:\n${botList}`,
+        );
+      }
+    } else {
+      // No bot specified, take the bot that the message was written on
+      channelBot = bot;
+    }
+
+    let labelChannel = message.channel;
+
+    if (channelID === 'this') {
+      // Take this channel and this bot
+      labelChannel = message.channel;
+      channelBot = bot;
+    } else {
+      labelChannel = channelBot.getChannelByID(channelID);
+    }
+
+    let label = channelLabel.trim();
+
+    // Check if the user wants to reset the label
+    if (label === 'reset') {
+      label = undefined;
+      bot.sendMessage(
+        message.channel,
+        `Removing the label of channel ${labelChannel.id} on ${channelBot.name}.`,
+      );
+    } else {
+      bot.sendMessage(
+        message.channel,
+        `Changing the label of channel ${labelChannel.id} on ${channelBot.name} to '${label}'.`,
+      );
+    }
+
+    // Save locally
+    labelChannel.label = label;
+
+    // Save in the JSON file
+    const subscribers = DataManager.getSubscriberData();
+    const channels = subscribers[channelBot.name];
+
+    // Check if the channel is already registered
+    const existingChannelId = channels.findIndex((ch) => labelChannel.isEqual(ch.id));
+    if (existingChannelId >= 0) {
+      const existingChannel = channels[existingChannelId];
+      // Update label
+      existingChannel.label = label;
+
+      // Remove unnecessary entries
+      if (
+        existingChannel.gameSubs.length === 0 &&
+        !existingChannel.prefix &&
+        !existingChannel.label
+      ) {
+        channelBot.logger.debug('Removing unnecessary channel entry...');
+        channels.splice(existingChannelId, 1);
+      } else {
+        channels[existingChannelId] = existingChannel;
+      }
+      // Save changes
+      subscribers[channelBot.name] = channels;
+      DataManager.setSubscriberData(subscribers);
+    } else {
+      // Add channel with the new label
+      channels.push({
+        gameSubs: [],
+        id: labelChannel.id,
+        label,
+      });
+      // Save the changes
+      subscribers[channelBot.name] = channels;
+      DataManager.setSubscriberData(subscribers);
+    }
+  },
+  // Default action
+  async (message) => {
+    if (message.isEmpty()) {
+      const label = message.channel.label;
+
+      if (label) {
+        message.reply(
+          `The label currenctly used on this channel is '${label}'.\nYou can change the label of a channel by using '<bot name> <channel id> <channel label>'.\n` +
+            `Use 'this' as channel id to change the label of this channel.`,
+        );
+      } else {
+        message.reply(
+          `This channel does not have a label.\nYou can change the label of a channel by using '<bot name> <channel id> <channel label>'.\n` +
+            `Use 'this' as channel id to change the label of this channel.`,
+        );
+      }
+    } else {
+      // Check if an ID and bot has been specified
+      const channelIDMatch = /^\s*(?:(?<botName>\w+)\s+)?(?<channelID>(?:(?:\+|-)?\d+)|(?:this))$/.exec(
+        message.content,
+      );
+      if (channelIDMatch) {
+        const channel = message.getBot().getChannelByID(channelIDMatch.groups.channelID);
+        const botName = channelIDMatch.groups.botName;
+
+        let channelBot = message.getBot();
+
+        if (botName) {
+          channelBot = getBots().find((client) => client.name === botName) ?? message.getBot();
+        }
+
+        const label = channel.label;
+
+        if (label) {
+          message.reply(
+            `The label currenctly used on channel ${channel.id} is '${label}'.\nYou can change its label by using ` +
+              `'${channelBot.name} ${channel.id} <channel label>' as command argument.`,
+          );
+        } else {
+          message.reply(
+            `Channel ${channel.id} does not have a label.\nYou can change the label of it by using ` +
+              `'${channelBot.name} ${channel.id} <channel label>' as command argument.`,
+          );
+        }
+      } else {
+        message.reply(
+          `'${message.content}' is an invalid configuration. Try to use '<bot name> <channel id> <channel label>'.\n` +
+            `Use 'this' as channel id to change the label of this channel.`,
+        );
+      }
+    }
+  },
+  UserRole.OWNER,
+);
+
 /**
  * The group containing all available commands.
  * They share the channels prefix as prefix, e.g. '/' for Telegram.
@@ -745,6 +902,7 @@ const commands: CommandGroup = new CommandGroup(
     notifyAllCmd,
     notifyGameSubsCmd,
     telegramCmdsCmd,
+    labelCmd,
   ],
 );
 

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -326,7 +326,7 @@ const prefixCmd = new TwoPartCommand(
     if (existingChannelId >= 0) {
       const existingChannel = channels[existingChannelId];
       // Update prefix
-      existingChannel.prefix = newPrefix !== bot.prefix ? newPrefix : '';
+      existingChannel.prefix = newPrefix !== bot.prefix ? newPrefix : undefined;
 
       // Remove unnecessary entries
       if (existingChannel.gameSubs.length === 0 && !existingChannel.prefix) {

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -725,7 +725,6 @@ const labelCmd = new TwoPartCommand(
 
     if (channelID === 'this') {
       // Take this channel and this bot
-      labelChannel = message.channel;
       channelBot = bot;
     } else {
       labelChannel = channelBot.getChannelByID(channelID);
@@ -767,7 +766,9 @@ const labelCmd = new TwoPartCommand(
         !existingChannel.prefix &&
         !existingChannel.label
       ) {
-        channelBot.logger.debug('Removing unnecessary channel entry...');
+        channelBot.logger.debug(
+          `Removing unnecessary entry for channel ${labelChannel.getLabel()}...`,
+        );
         channels.splice(existingChannelId, 1);
       } else {
         channels[existingChannelId] = existingChannel;

--- a/src/managers/data_manager.ts
+++ b/src/managers/data_manager.ts
@@ -12,8 +12,10 @@ export type subscriber = {
   gameSubs: string[];
   /** The channel ID. */
   id: string;
-  /** The prefix the channel uses */
-  prefix: string;
+  /** The label of the channel. */
+  label?: string;
+  /** The prefix the channel uses. */
+  prefix?: string;
 };
 
 /** The data for the subscribers. */


### PR DESCRIPTION
**Description**:
Removes the permission checks when sending messages to Telegram channels. Hopefully this will fix some channels not recieving notifications or the bot hitting the rate limit.
Additionally, this adds channel labeling. Bot owners can use `label <bot name> <channel id> <channel label>` to add a label to a channel. This will be used during logging to simplify debugging.
Closes #206.

**Checklist**:

- [x] Tested the bot on both clients with a few commands
- [x] Updated the [`README`](README.md) if necessary
- [x] Updated the version string in the [`package.json`](package.json) if necessary
