### PR TITLE
Fix unsubscribe message

### DIFF
--- a/src/bots/bot.ts
+++ b/src/bots/bot.ts
@@ -114,10 +114,11 @@ export default abstract class BotClient {
     for (let i = 0; i < channels.length; i += 1) {
       const sub = channels[i];
       if (channel.isEqual(sub.id)) {
-        // Check if the channel already subscribed to the game's feed
+        // Check if the channel is already subscribed to the game's feed
         if (sub.gameSubs.find((gameName) => gameName === game.name)) {
           return false;
         }
+
         // Add the game to the subscriptions
         sub.gameSubs.push(game.name);
         channels[i] = sub;
@@ -153,6 +154,12 @@ export default abstract class BotClient {
     const existingSubId = subs.findIndex((sub) => channel.isEqual(sub.id));
     if (existingSubId >= 0) {
       const sub = subs[existingSubId];
+
+      // Check if the channel did not subscribed to the game's feed
+      if (!sub.gameSubs.find((gameName) => gameName === game.name)) {
+        return false;
+      }
+
       // Unsubscribe
       sub.gameSubs = sub.gameSubs.filter((gameName: string) => gameName !== game.name);
 

--- a/src/bots/bot.ts
+++ b/src/bots/bot.ts
@@ -115,10 +115,8 @@ export default abstract class BotClient {
       const sub = channels[i];
       if (channel.isEqual(sub.id)) {
         // Check if the channel already subscribed to the game's feed
-        for (const gameName of sub.gameSubs) {
-          if (gameName === game.name) {
-            return false;
-          }
+        if (sub.gameSubs.find((gameName) => gameName === game.name)) {
+          return false;
         }
         // Add the game to the subscriptions
         sub.gameSubs.push(game.name);

--- a/src/bots/bot.ts
+++ b/src/bots/bot.ts
@@ -155,7 +155,7 @@ export default abstract class BotClient {
     if (existingSubId >= 0) {
       const sub = subs[existingSubId];
 
-      // Check if the channel did not subscribed to the game's feed
+      // Check if the channel did not subscribe to the game's feed
       if (!sub.gameSubs.find((gameName) => gameName === game.name)) {
         return false;
       }


### PR DESCRIPTION
**Description**:
Fix the bot not recognizing when a user is trying to unsubscribe a game that they have not subscribed to in the first place. This occured when a user did not subscribe to the specified game, but has other subscriptions active.

**Checklist**:

- [x] Tested the bot on both clients with a few commands
- [x] Updated the [`README`](README.md) if necessary
- [ ] Updated the version string in the [`package.json`](package.json) if necessary
