### PR TITLE
Improve telegram sendMessage()

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,6 +31,7 @@
     "@typescript-eslint/explicit-function-return-type": "off",
     "class-methods-use-this": "off",
     "no-underscore-dangle": ["warn", { "allowAfterThis": true }],
+    "no-param-reassign": ["error", { "props": false }],
     "jest/no-disabled-tests": "warn",
     "jest/no-focused-tests": "error",
     "jest/no-identical-title": "error",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gamefeeder",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "description": "A notification bot for several games, available on Discord and Telegram.",
   "main": "src/_main.ts",
   "repository": {
@@ -80,7 +80,9 @@
     "request": "2.88.2",
     "request-promise-native": "1.0.8",
     "rss-parser": "3.7.5",
+    "smart-request-balancer": "2.1.1",
     "snoowrap": "1.20.1",
+    "throttled-queue": "^1.0.7",
     "turndown": "5.0.3",
     "winston": "3.2.1"
   }

--- a/src/bots/telegram.ts
+++ b/src/bots/telegram.ts
@@ -362,8 +362,9 @@ export default class TelegramBot extends BotClient {
       return true;
     } catch (err) {
       this.logger.error(
-        `Failed to add message for channel ${channel.label} in the queue, error: ${err}. \
-        This is most likely because the bot has been blocked, disabling subscriber.`,
+        `Failed to add message for channel ${channel.label} in the queue. \
+        \n - Error: ${err}. \
+        \n - This is most likely because the bot has been blocked, disabling subscriber.`,
       );
       channel.disabled = true;
       return false;

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -117,13 +117,49 @@ export default class Channel {
     }
   }
 
+  // Disabled channels won't receive automatic updates
+  private _disabled: boolean;
+  get disabled() {
+    return this._disabled;
+  }
+  set disabled(value) {
+    // Save locally
+    this._disabled = value;
+
+    // Save in the JSON file
+    const subscribers = DataManager.getSubscriberData();
+    const channels = subscribers[this.bot.name];
+
+    // Check if the channel is already registered
+    const existingChannelId = channels.findIndex((ch) => this.isEqual(ch.id));
+    if (existingChannelId < 0) {
+      this.bot.logger.error(`Can't disable channel ${this.label}, not found in subscribers.`);
+    }
+    const existingChannel = channels[existingChannelId];
+
+    // Update prefix
+    existingChannel.disabled = value;
+
+    // Save the changes
+    subscribers[this.bot.name] = channels;
+    DataManager.setSubscriberData(subscribers);
+  }
+
   /** Creates a new Channel. */
-  constructor(id: string, bot: BotClient, gameSubs?: Game[], prefix?: string, label?: string) {
+  constructor(
+    id: string,
+    bot: BotClient,
+    gameSubs?: Game[],
+    prefix?: string,
+    label?: string,
+    disabled = false,
+  ) {
     this.id = id;
     this.bot = bot;
     this.gameSubs = gameSubs || [];
     this._prefix = prefix;
     this._label = label;
+    this._disabled = disabled;
   }
   /** Compares the channel to another channel.
    *

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -137,8 +137,12 @@ export default class Channel {
     }
     const existingChannel = channels[existingChannelId];
 
-    // Update prefix
+    // Update status
     existingChannel.disabled = value;
+    // Delete disabled = false entries to save space
+    if (value === false) {
+      delete existingChannel.disabled;
+    }
 
     // Save the changes
     subscribers[this.bot.name] = channels;

--- a/src/managers/data_manager.ts
+++ b/src/managers/data_manager.ts
@@ -7,7 +7,7 @@ export enum DATA {
 }
 
 /** The data for one subscribing channel. */
-export type subscriber = {
+export type Subscriber = {
   /** The names of the games the channel subscribed to. */
   gameSubs: string[];
   /** The channel ID. */
@@ -16,15 +16,17 @@ export type subscriber = {
   label?: string;
   /** The prefix the channel uses. */
   prefix?: string;
+  /** Disabled subscribers won't receive automatic updates. */
+  disabled?: boolean;
 };
 
 /** The data for the subscribers. */
 export type SubscriberData = {
-  [index: string]: subscriber[];
+  [index: string]: Subscriber[];
   /** The discord subs. */
-  discord: subscriber[];
+  discord: Subscriber[];
   /** The telegram subs. */
-  telegram: subscriber[];
+  telegram: Subscriber[];
 };
 
 /** The data for the updater. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -4750,6 +4750,14 @@ slice-ansi@^2.1.0:
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
 
+smart-request-balancer@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/smart-request-balancer/-/smart-request-balancer-2.1.1.tgz#c6ed666a8dfed2bb0a338cd2cba9aff7526ffcb9"
+  integrity sha512-4AnMhV4amviBUGKeACOricuj4dhihf2P9Z/s3+cvZ3kjFxUwEV74JL9JTdK3/7Im84cC3J9ANeg+sUjSv0buxQ==
+  dependencies:
+    debug "^4.1.1"
+    uuid "^3.3.2"
+
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
@@ -5109,6 +5117,11 @@ throat@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-5.0.0.tgz#c5199235803aad18754a667d659b5e72ce16764b"
   integrity sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==
+
+throttled-queue@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/throttled-queue/-/throttled-queue-1.0.7.tgz#da7ed6702941993044a1c5fd2ac3a58582dd2977"
+  integrity sha512-/HT49S7m+NvdyJMoMRzIYlawKjeHn8jEc8TZaGmFi5IBu09hIiU/QoP1zcrB9X2qsVC11PgfRfqd8zEQs7PlEA==
 
 through@^2.3.6:
   version "2.3.8"


### PR DESCRIPTION
**Description**:

- Add messages to a queue before sending them to avoid hitting the
  telegram API rate limit
- Retry sending messages for failed attempts up to max retries
- After max retries have been reached, disable the subscriber
- Skip sending automated messages to subscribers
- Re-enable subscriber if he sends any command

**Checklist**:

- [x] Tested the bot on both clients with a few commands
- [x] Updated the [`README`](README.md) if necessary
- [x] Updated the version string in the [`package.json`](package.json) if necessary
