### PR TITLE
Add extension to stats command to display stats about a specific game

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -63,7 +63,7 @@ So far, we are providing the following commands:
 | `about`                                         | User  | Display information about this bot.                                             |
 | `settings`                                      | User  | Display an overview of the settings you can configure for the bot.              |
 | `games`                                         | User  | Display a list of all available games.                                          |
-| `stats`                                         | User  | Display some stats about the bot.                                               |
+| `stats <game name (optional)>`                  | User  | Display some stats about the bot or a specific game.                            |
 | `ping`                                          | User  | Test the delay of the bot.                                                      |
 | `debug`                                         | User  | Display useful debug information.                                               |
 | `flip`                                          | User  | Flip a coin.                                                                    |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gamefeeder",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "A notification bot for several games, available on Discord and Telegram.",
   "main": "src/_main.ts",
   "repository": {

--- a/src/bots/bot.ts
+++ b/src/bots/bot.ts
@@ -236,10 +236,10 @@ export default abstract class BotClient {
   public abstract async getChannelUserCount(channel: Channel): Promise<number>;
 
   /** Gets the number of users for this bot. */
-  public abstract async getUserCount(): Promise<number>;
+  public abstract async getUserCount(game?: Game): Promise<number>;
 
   /** Gets the number of channels for this bot. */
-  public abstract async getChannelCount(): Promise<number>;
+  public abstract async getChannelCount(game?: Game): Promise<number>;
 
   /** Get the channels subscribed on this bot client.
    *

--- a/src/bots/discord.ts
+++ b/src/bots/discord.ts
@@ -10,6 +10,7 @@ import { StrUtil, mapAsync } from '../util/util';
 import Message from '../message';
 import Permissions from '../permissions';
 import ProjectManager from '../managers/project_manager';
+import Game from '../game';
 
 export default class DiscordBot extends BotClient {
   private static standardBot: DiscordBot;
@@ -71,38 +72,50 @@ export default class DiscordBot extends BotClient {
     return 0;
   }
 
-  public async getChannelCount(): Promise<number> {
+  public async getChannelCount(game?: Game): Promise<number> {
     let channels = this.getBotChannels();
     // Save guilds
     const seenGuilds = new Map<string, boolean>();
     // Only consider each guild once
     channels = channels.filter((channel) => {
+      if (game && !channel.gameSubs.includes(game)) {
+        return false;
+      }
+
       const discordChannel = this.bot.channels.cache.get(channel.id);
+
       if (discordChannel instanceof TextChannel) {
         const guildID = discordChannel.guild.id;
         const isDuplicate = seenGuilds.get(guildID);
         seenGuilds.set(guildID, true);
         return !isDuplicate;
       }
+
       return true;
     });
 
     return channels.length;
   }
 
-  public async getUserCount(): Promise<number> {
+  public async getUserCount(game?: Game): Promise<number> {
     let channels = this.getBotChannels();
     // Save guilds
     const seenGuilds = new Map<string, boolean>();
     // Only consider each guild once
     channels = channels.filter((channel) => {
+      if (game && !channel.gameSubs.includes(game)) {
+        return false;
+      }
+
       const discordChannel = this.bot.channels.cache.get(channel.id);
+
       if (discordChannel instanceof TextChannel) {
         const guildID = discordChannel.guild.id;
         const isDuplicate = seenGuilds.get(guildID);
         seenGuilds.set(guildID, true);
         return !isDuplicate;
       }
+
       return true;
     });
 

--- a/src/bots/telegram.ts
+++ b/src/bots/telegram.ts
@@ -9,6 +9,7 @@ import MDRegex from '../util/regex';
 import { StrUtil, mapAsync } from '../util/util';
 import Message from '../message';
 import Permissions from '../permissions';
+import Game from '../game';
 
 // node-telegram-bot-api includes snake_case properties
 /* eslint-disable @typescript-eslint/camelcase */
@@ -177,16 +178,26 @@ export default class TelegramBot extends BotClient {
     }
   }
 
-  public async getUserCount(): Promise<number> {
+  public async getUserCount(game?: Game): Promise<number> {
     const channels = this.getBotChannels();
+
+    if (game) {
+      channels.filter((channel) => channel.gameSubs.includes(game));
+    }
+
     const userCounts = await mapAsync(channels, async (botChannel) => botChannel.getUserCount());
     const userCount = userCounts.reduce((prevValue, curValue) => prevValue + curValue, 0);
     return userCount;
   }
 
-  public async getChannelCount(): Promise<number> {
-    const botChannels = this.getBotChannels();
-    return botChannels.length;
+  public async getChannelCount(game?: Game): Promise<number> {
+    const channels = this.getBotChannels();
+
+    if (game) {
+      channels.filter((channel) => channel.gameSubs.includes(game));
+    }
+
+    return channels.length;
   }
 
   public async getOwners(): Promise<User[]> {


### PR DESCRIPTION
**Description**:
Modify `stats` command to take a game to display stats for that specific game.
Usage: `stats <game name (optional)>`
Closes #225.

**Checklist**:
- [x] Tested the bot on both clients with a few commands
- [x] Updated the [`README`](README.md) if necessary
- [x] Updated the version string in the [`package.json`](package.json) if necessary
