### PR TITLE
Add the Steam community announcements as feed for Dota Underlords

### DIFF
--- a/config/games/underlords.json
+++ b/config/games/underlords.json
@@ -17,7 +17,8 @@
       }
     ],
     "steam": {
-      "appID": 1046930
+      "appID": 1046930,
+      "feeds": ["steam_community_announcements"]
     },
     "rss": []
   }

--- a/docs/README.md
+++ b/docs/README.md
@@ -108,6 +108,7 @@ So far, we are supporting the following games:
   - Posts on the [TF2 blog](http://www.teamfortress.com/?tab=blog)
 - <strong align="left">Dota Underlords</strong> <img src="https://pbs.twimg.com/profile_images/1139243347237691392/PzgWEKp7_400x400.png" height="17px"/>
   - Reddit posts by [/u/wykrhm](https://www.reddit.com/user/wykrhm/posts/) on [/r/underlords](https://www.reddit.com/r/underlords/)
+  - Posts on the [Steam feed](https://steamcommunity.com/app/1046930/allnews/)
 
 ### Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gamefeeder",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "A notification bot for several games, available on Discord and Telegram.",
   "main": "src/_main.ts",
   "repository": {


### PR DESCRIPTION
**Description**:
Adds the [Dota Underlords Steam feed](https://steamcommunity.com/app/1046930/allnews/) as a provider to increase the update coverage for Dota Underlords.

**Checklist**:
- [x] Tested the bot on both clients with a few commands
- [x] Updated the [`README`](README.md) if necessary
- [x] Updated the version string in the [`package.json`](package.json) if necessary
