### PR TITLE
Change game icon host to Imgur

### DIFF
--- a/config/games/artifact.json
+++ b/config/games/artifact.json
@@ -3,7 +3,7 @@
   "label": "Artifact",
   "aliases": ["artifact", "card game", "dcg"],
   "color": "#FFD700",
-  "icon": "https://artifactwiki.com/wiki/Special:Redirect/file/Artifact_Cutout.png",
+  "icon": "https://i.imgur.com/DblOFap.png",
   "providers": {
     "reddit": [
       {

--- a/config/games/csgo.json
+++ b/config/games/csgo.json
@@ -3,7 +3,7 @@
   "label": "CS:GO",
   "aliases": ["counter strike", "global offensive", "csgo", "cs:go"],
   "color": "#000000",
-  "icon": "http://media.steampowered.com/apps/csgo/blog/images/tags/csgo_blog_tag.png",
+  "icon": "https://i.imgur.com/2ONuRD3.png",
   "providers": {
     "reddit": [
       {

--- a/config/games/dota.json
+++ b/config/games/dota.json
@@ -3,7 +3,7 @@
   "label": "Dota 2",
   "aliases": ["dota", "dota2", "dota 2", "d2"],
   "color": "#CC0000",
-  "icon": "http://cdn.dota2.com/apps/dota2/images/reborn/day1/Dota2OrangeLogo.png",
+  "icon": "https://i.imgur.com/aRVbvDh.png",
   "telegramIVTemplates": [
     {
       "domain": "dota2.com",

--- a/config/games/factorio.json
+++ b/config/games/factorio.json
@@ -3,7 +3,7 @@
   "label": "Factorio",
   "aliases": ["factorio", "fff"],
   "color": "#C67328",
-  "icon": "https://wiki.factorio.com/images/Factorio-icon.png",
+  "icon": "https://i.imgur.com/7D0A9eT.png",
   "providers": {
     "reddit": [
       {

--- a/config/games/steam.json
+++ b/config/games/steam.json
@@ -3,7 +3,7 @@
   "label": "Steam",
   "aliases": ["steam"],
   "color": "#0B5A8E",
-  "icon": "https://pbs.twimg.com/profile_images/887778636102721536/Nxgl7xz4_400x400.jpg",
+  "icon": "https://i.imgur.com/QbzZxrC.png",
   "providers": {
     "reddit": [
       {

--- a/config/games/tf2.json
+++ b/config/games/tf2.json
@@ -3,7 +3,7 @@
   "label": "Team Fortress 2",
   "aliases": ["team fortress 2", "team fortress", "tf", "tf2"],
   "color": "#9A4713",
-  "icon": "http://icons.iconarchive.com/icons/papirus-team/papirus-apps/256/team-fortress-2-icon.png",
+  "icon": "https://i.imgur.com/zaQObOc.png",
   "providers": {
     "reddit": [
       {

--- a/config/games/underlords.json
+++ b/config/games/underlords.json
@@ -3,7 +3,7 @@
   "label": "Dota Underlords",
   "aliases": ["underlords", "dota underlords", "du"],
   "color": "#FFFFFF",
-  "icon": "https://styles.redditmedia.com/t5_117kpk/styles/communityIcon_87bnogkb67431.png",
+  "icon": "https://i.imgur.com/gaYsZ7Z.png",
   "providers": {
     "reddit": [
       {

--- a/docs/README.md
+++ b/docs/README.md
@@ -90,25 +90,25 @@ So far, we are providing the following commands:
 
 So far, we are supporting the following games:
 
-- <strong align="left">Artifact</strong> <img src="https://artifactwiki.com/wiki/Special:Redirect/file/Artifact_Cutout.png" height="17px"/>
+- <strong align="left">Artifact</strong> <img src="https://i.imgur.com/DblOFap.png" height="17px"/>
   - Reddit posts by [/u/Magesunite](https://www.reddit.com/user/Magesunite/posts/) and [/u/wykrhm](https://www.reddit.com/user/wykrhm/posts/) on [/r/Artifact](https://www.reddit.com/r/Artifact/)
   - Posts on the [Steam feed](https://steamcommunity.com/games/583950/announcements)
-- <strong align="left">CS:GO</strong> <img src="http://media.steampowered.com/apps/csgo/blog/images/tags/csgo_blog_tag.png" height="17px"/>
+- <strong align="left">CS:GO</strong> <img src="https://i.imgur.com/2ONuRD3.png" height="17px"/>
   - Reddit posts by [/u/wickedplayer494](https://www.reddit.com/user/wickedplayer494/posts/) on [/r/csgo](https://www.reddit.com/r/csgo/)
   - Posts on the [CS:GO blog](https://blog.counter-strike.net/)
-- <strong align="left">Dota 2</strong> <img src="http://cdn.dota2.com/apps/dota2/images/reborn/day1/Dota2OrangeLogo.png" height="17px"/>
+- <strong align="left">Dota 2</strong> <img src="https://i.imgur.com/aRVbvDh.png" height="17px"/>
   - Reddit posts by [/u/Kappa_Man](https://www.reddit.com/user/Kappa_Man/posts/), [/u/TheZett](https://www.reddit.com/user/TheZett/posts/) and [/u/wykrhm](https://www.reddit.com/user/wykrhm/posts/) on [/r/DotA2](https://www.reddit.com/r/DotA2/)
   - Reddit posts by [/u/Kappa_Man](https://www.reddit.com/user/Kappa_Man/posts/), [/u/Magesunite](https://www.reddit.com/user/Magesunite/posts/) and [/u/MSTRMN\_](https://www.reddit.com/user/MSTRMN_/posts/) on [/r/DotaPatches](https://www.reddit.com/r/DotaPatches/)
   - Gamplay updates on the [Dota 2 patch page](https://www.dota2.com/patches)
   - Blog posts on the [Dota 2 Blog](http://blog.dota2.com/?l=english)
-- <strong align="left">Factorio</strong> <img src="https://wiki.factorio.com/images/Factorio-icon.png" height="17px"/>
+- <strong align="left">Factorio</strong> <img src="https://i.imgur.com/7D0A9eT.png" height="17px"/>
   - Posts on the [Steam feed](https://steamcommunity.com/games/427520/announcements)
-- <strong align="left">Steam</strong> <img src="https://pbs.twimg.com/profile_images/887778636102721536/Nxgl7xz4_400x400.jpg" height="17px"/>
+- <strong align="left">Steam</strong> <img src="https://i.imgur.com/QbzZxrC.png" height="17px"/>
   - Reddit posts by [/u/wickedplayer494](https://www.reddit.com/user/wickedplayer494/posts/) on [/r/Steam](https://www.reddit.com/r/Steam/)
   - Posts on the [Steam blog](https://steamcommunity.com/app/593110/announcements/)
-- <strong align="left">Team Fortress 2</strong> <img src="http://icons.iconarchive.com/icons/papirus-team/papirus-apps/256/team-fortress-2-icon.png" height="17px"/>
+- <strong align="left">Team Fortress 2</strong> <img src="https://i.imgur.com/zaQObOc.png" height="17px"/>
   - Posts on the [TF2 blog](http://www.teamfortress.com/?tab=blog)
-- <strong align="left">Dota Underlords</strong> <img src="https://pbs.twimg.com/profile_images/1139243347237691392/PzgWEKp7_400x400.png" height="17px"/>
+- <strong align="left">Dota Underlords</strong> <img src="https://i.imgur.com/gaYsZ7Z.png" height="17px"/>
   - Reddit posts by [/u/wykrhm](https://www.reddit.com/user/wykrhm/posts/) on [/r/underlords](https://www.reddit.com/r/underlords/)
   - Posts on the [Steam feed](https://steamcommunity.com/app/1046930/allnews/)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gamefeeder",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "A notification bot for several games, available on Discord and Telegram.",
   "main": "src/_main.ts",
   "repository": {


### PR DESCRIPTION
**Description**:
Changes the image host of the games' icons to Imgur to insure that the icons are accessable at all times. I also edited the images slightly to improve their display as circular icons.

**Checklist**:

- [x] Tested the bot on both clients with a few commands
- [x] Updated the [`README`](README.md) if necessary
- [x] Updated the version string in the [`package.json`](package.json) if necessary
