### PR TITLE
#248 Add Artifact 2.0 beta Steam feed

### DIFF
--- a/config/games/artifact.json
+++ b/config/games/artifact.json
@@ -25,7 +25,7 @@
       }
     ],
     "steam": {
-      "appID": 583950,
+      "appID": 1269260,
       "feeds": ["steam_community_announcements"]
     },
     "rss": []

--- a/docs/README.md
+++ b/docs/README.md
@@ -92,7 +92,7 @@ So far, we are supporting the following games:
 
 - <strong align="left">Artifact</strong> <img src="https://i.imgur.com/DblOFap.png" height="17px"/>
   - Reddit posts by [/u/Magesunite](https://www.reddit.com/user/Magesunite/posts/) and [/u/wykrhm](https://www.reddit.com/user/wykrhm/posts/) on [/r/Artifact](https://www.reddit.com/r/Artifact/)
-  - Posts on the [Steam feed](https://steamcommunity.com/games/583950/announcements)
+  - Posts on the [Steam feed](https://steamcommunity.com/games/1269260/announcements)
 - <strong align="left">CS:GO</strong> <img src="https://i.imgur.com/2ONuRD3.png" height="17px"/>
   - Reddit posts by [/u/wickedplayer494](https://www.reddit.com/user/wickedplayer494/posts/) on [/r/csgo](https://www.reddit.com/r/csgo/)
   - Posts on the [CS:GO blog](https://blog.counter-strike.net/)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gamefeeder",
-  "version": "0.13.6",
+  "version": "0.13.7",
   "description": "A notification bot for several games, available on Discord and Telegram.",
   "main": "src/_main.ts",
   "repository": {


### PR DESCRIPTION
**Description**:
Replaces the Steam app ID of Artifact to `1269260`, the Artifact 2.0 beta.
Closes #248.

**Checklist**:

- [x] Tested the bot on both clients with a few commands
- [x] Updated the [`README`](README.md) if necessary
- [x] Updated the version string in the [`package.json`](package.json) if necessary
