### PR TITLE
#250 Add Satisfactory as game

### DIFF
--- a/config/games/satisfactory.json
+++ b/config/games/satisfactory.json
@@ -1,0 +1,22 @@
+{
+  "name": "satisfactory",
+  "label": "Satisfactory",
+  "aliases": ["satisfactory"],
+  "color": "#283b4e",
+  "icon": "https://i.imgur.com/RgtzvdT.png",
+  "telegramIVTemplates": [],
+  "providers": {
+    "reddit": [
+      {
+        "urlFilters": [],
+        "subreddit": "SatisfactoryGame",
+        "users": []
+      }
+    ],
+    "steam": {
+      "appID": 526870,
+      "feeds": ["steam_community_announcements"]
+    },
+    "rss": []
+  }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -103,6 +103,8 @@ So far, we are supporting the following games:
   - Blog posts on the [Dota 2 Blog](http://blog.dota2.com/?l=english)
 - <strong align="left">Factorio</strong> <img src="https://i.imgur.com/7D0A9eT.png" height="17px"/>
   - Posts on the [Steam feed](https://steamcommunity.com/games/427520/announcements)
+- <strong align="left">Satisfactory</strong> <img src="https://i.imgur.com/RgtzvdT.png" height="17px"/>
+  - Posts on the [Steam feed](https://steamcommunity.com/games/526870/announcements)
 - <strong align="left">Steam</strong> <img src="https://i.imgur.com/QbzZxrC.png" height="17px"/>
   - Reddit posts by [/u/wickedplayer494](https://www.reddit.com/user/wickedplayer494/posts/) on [/r/Steam](https://www.reddit.com/r/Steam/)
   - Posts on the [Steam blog](https://steamcommunity.com/app/593110/announcements/)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gamefeeder",
-  "version": "0.13.7",
+  "version": "0.13.8",
   "description": "A notification bot for several games, available on Discord and Telegram.",
   "main": "src/_main.ts",
   "repository": {


### PR DESCRIPTION
**Description**:
Adds Satisfactory as game, using the [Steam feed](https://steamcommunity.com/games/526870/announcements).
Closes #250.

**Checklist**:

- [x] Tested the bot on both clients with a few commands
- [x] Updated the [`README`](README.md) if necessary
- [x] Updated the version string in the [`package.json`](package.json) if necessary
