### PR TITLE
#289 Limit Discord embed titles if they exceed the maximum length

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gamefeeder",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "A notification bot for several games, available on Discord and Telegram.",
   "main": "src/_main.ts",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gamefeeder",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "A notification bot for several games, available on Discord and Telegram.",
   "main": "src/_main.ts",
   "repository": {

--- a/src/bots/discord.ts
+++ b/src/bots/discord.ts
@@ -12,6 +12,13 @@ import Permissions from '../permissions';
 import ProjectManager from '../managers/project_manager';
 import Game from '../game';
 
+/** The maximum amount of characters allowed in the title of embeds. */
+const EMBED_TITLE_LIMIT = 256;
+/** The amount of characters needed to format an H1 text. */
+const HEADER_FORMAT_CHARS = 4 * 2;
+/** The maximum amount of characters allowed in the content of embeds. */
+const EMBED_CONTENT_LIMIT = 2048;
+
 export default class DiscordBot extends BotClient {
   private static standardBot: DiscordBot;
   private bot: DiscordAPI.Client;
@@ -394,8 +401,15 @@ export default class DiscordBot extends BotClient {
     const embed = new MessageEmbed();
     // Title
     if (notification.title) {
-      const titleMD = DiscordBot.msgFromMarkdown(`#${notification.title.text}`, true);
+      // Respect title character limits
+      const limitedTitle = StrUtil.naturalLimit(
+        notification.title.text,
+        EMBED_TITLE_LIMIT - HEADER_FORMAT_CHARS,
+      );
+
+      const titleMD = DiscordBot.msgFromMarkdown(`#${limitedTitle}`, true).trim();
       embed.setTitle(titleMD);
+
       if (notification.title.link) {
         embed.setURL(notification.title.link);
       }
@@ -416,8 +430,8 @@ export default class DiscordBot extends BotClient {
     // Description
     if (notification.content) {
       const descriptionMD = DiscordBot.msgFromMarkdown(notification.content, true);
-      // 2048 is the maximum notification length
-      embed.setDescription(StrUtil.naturalLimit(descriptionMD, 2048));
+      // Respect the content character limit
+      embed.setDescription(StrUtil.naturalLimit(descriptionMD, EMBED_CONTENT_LIMIT));
     }
     // Footer
     if (notification.footer) {

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -110,7 +110,7 @@ export class StrUtil {
    * @param indicator - The indicator to use when the string is too long.
    */
   public static naturalLimit(str: string, limit: number, indicator?: string): string {
-    const newIndicator = indicator == null ? '...' : indicator;
+    const newIndicator = indicator ?? '...';
 
     if (newIndicator.length > limit) {
       throw new Error('The indicator must not be longer than the limit.');

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -109,16 +109,16 @@ export class StrUtil {
    * @param limit - The maximum length of the string.
    * @param indicator - The indicator to use when the string is too long.
    */
-  public static naturalLimit(str: string, limit: number, indicator?: string): string {
-    const newIndicator = indicator ?? '...';
-
-    if (newIndicator.length > limit) {
+  public static naturalLimit(str: string, limit: number, indicator = '...'): string {
+    if (indicator.length > limit) {
       throw new Error('The indicator must not be longer than the limit.');
     }
+
     if (str.length > limit) {
-      const cutStr = this.limit(str, limit - newIndicator.length);
-      return cutStr + newIndicator;
+      const cutStr = this.limit(str, limit - indicator.length);
+      return cutStr + indicator;
     }
+
     return str;
   }
 }


### PR DESCRIPTION
**Description**:
- Limit Discord embed titles if they exceed the maximum length

Closes #289.

**Checklist**:

- [x] Tested the bot on both clients with a few commands
- [x] Updated the [`README`](README.md) if necessary
- [x] Updated the version string in the [`package.json`](package.json) if necessary
