### PR TITLE
Fix tagging and CI workflow

### DIFF
--- a/.github/workflows/ci-flow.yml
+++ b/.github/workflows/ci-flow.yml
@@ -1,6 +1,11 @@
 name: ci-flow
 
-on: [pull_request]
+on:
+  pull_request:
+  # Also run it on pushes for main, for the badges
+  push:
+    branches:
+      - main
 
 jobs:
   CI:

--- a/.github/workflows/tag-flow.yml
+++ b/.github/workflows/tag-flow.yml
@@ -12,6 +12,6 @@ jobs:
       - name: Set global git conf
         run: git config --global user.email "" && git config --global user.name "github-actions"
       - name: Get current version
-        run: echo "::set-env name=gamefeeder_version::v$(jq -r '.version' package.json)"
+        run: echo "gamefeeder_version=v$(jq -r '.version' package.json)" >> $GITHUB_ENV
       - name: Create tag and push to GitHub
         run: git tag $gamefeeder_version && git push origin $gamefeeder_version || true


### PR DESCRIPTION
**Description**:
- Fix tagging workflow to use the new GitHub environment variables
- Fix CI workflow to also run on pushes to `main` (for the badges)

Closes #402.

**Checklist**:

- [x] Tested the bot on both clients with a few commands
- [x] Updated the [`README`](README.md) if necessary
- [x] Updated the version string in the [`package.json`](package.json) if necessary
