### PR TITLE
Disable broken minecraft rss

### DIFF
--- a/config/games/minecraft.json
+++ b/config/games/minecraft.json
@@ -10,11 +10,6 @@
         "subreddit": "Minecraft"
       }
     ],
-    "rss": [
-      {
-        "label": "Minecraft Blog",
-        "url": "https://minecraft.net/en-us/feeds/community-content/rss"
-      }
-    ]
+    "rss": []
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gamefeeder",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "description": "A notification bot for several games, available on Discord and Telegram.",
   "main": "src/_main.ts",
   "repository": {


### PR DESCRIPTION
**Description**:

Temporarily disable the broken Minecraft RSS feed until we fix it.

**Checklist**:

- [ ] Tested the bot on both clients with a few commands
- [ ] Updated the [`README`](README.md) if necessary
- [ ] Updated the version string in the [`package.json`](package.json) if necessary
