### PR TITLE
Improve parsing of Steam markup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gamefeeder",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "A notification bot for several games, available on Discord and Telegram.",
   "main": "src/_main.ts",
   "type": "module",

--- a/src/processors/steam_processor.ts
+++ b/src/processors/steam_processor.ts
@@ -37,18 +37,14 @@ export default class SteamProcessor extends PreProcessor {
   // [previewyoutube=link][/previewyoutube]
   public youTubeTagReg = /(?:\[previewyoutube=(.*?)\])(.*?)(?:\[\/previewyoutube\])/gs;
 
+  // Paragraphs, at least one empty line
   public paragraphReg = /(\n\r?[ ]*){2,}/g;
-
+  // Line breaks
   public lineBreakReg = /\n\r?/g;
 
   public process(htmlContent: string): string {
     let newContent = htmlContent;
 
-    if (htmlContent.includes('※')) {
-      console.debug('BEFORE');
-      console.debug(htmlContent);
-      console.debug('\n\n');
-    }
     // Remove link hosts
     newContent = newContent.replace(this.linkHostReg, () => '');
     // Remove link filters

--- a/src/processors/steam_processor.ts
+++ b/src/processors/steam_processor.ts
@@ -5,41 +5,50 @@ export default class SteamProcessor extends PreProcessor {
   public static logger = new Logger('SteamProcessor');
 
   // <span class="bb_link_host">[github.com]</span>
-  public linkHostReg = /(?:<span class="bb_link_host">\[?)(.*?)(?:\]?<\/span>)/g;
+  public linkHostReg = /(?:<span class="bb_link_host">\[?)(.*?)(?:\]?<\/span>)/gs;
   // <div class="bb_h1">Text</div>
-  public headerReg = /(?:<div class="bb_h(\d)">)(.*?)(?:<\/div>)/g;
+  public headerReg = /(?:<div class="bb_h(\d)">)(.*?)(?:<\/div>)/gs;
   // <a href="https://steamcommunity.com/linkfilter/?url=https://github.com">Text</a>
   public linkFilter = /(?:(?<=")https:\/\/steamcommunity\.com\/linkfilter\/\?url=(.*?)(?="))/g;
 
   // [list] ... [/list]
   public listReg = /(?:\[list\]\s*((?:.|\s)*?)\[\/list\])/gm;
   // [*] List item
-  public listElemReg = /(?:\[\*\])\s*(.*?)\s*\n/g;
+  public listElemReg = /(?:\[\*\])\s*(.*)\s*/g;
 
   // [url=https://github.com]Text[/url]
   public urlTagReg = /(?:\[url=(.*?)\/?\])(.*?)(?:\/?\[\/url\/?\])/g;
   // [h1]Text[/h1]
-  public headerTagReg = /(?:\[h(\d)\/?\])(.*?)(?:\/?\[\/h\d\/?\])/g;
+  public headerTagReg = /(?:\[h(\d)\/?\])(.*?)(?:\/?\[\/h\d\/?\])/gs;
   // [b]Text[/b]
-  public boldTagReg = /(?:\[b\/?\])(.*?)(?:\/?\[\/b\/?\])/g;
+  public boldTagReg = /(?:\[b\/?\])(.*?)(?:\/?\[\/b\/?\])/gs;
   // [u]Text[/u]
-  public underlineTagReg = /(?:\[u\/?\])(.*?)(?:\/?\[\/u\/?\])/g;
+  public underlineTagReg = /(?:\[u\/?\])(.*?)(?:\/?\[\/u\/?\])/gs;
   // [i]Text[/i]
-  public italicTagReg = /(?:\[i\/?\])(.*?)(?:\/?\[\/i\/?\])/g;
+  public italicTagReg = /(?:\[i\/?\])(.*?)(?:\/?\[\/i\/?\])/gs;
   // [strike]Text[/strike]
-  public strikethroughTagReg = /(?:\[strike\/?\])(.*?)(?:\/?\[\/strike\/?\])/g;
+  public strikethroughTagReg = /(?:\[strike\/?\])(.*?)(?:\/?\[\/strike\/?\])/gs;
   // [spoiler]Text[/spoiler]
-  public spoilerTagReg = /(?:\[spoiler\/?\])(.*?)(?:\/?\[\/spoiler\/?\])/g;
+  public spoilerTagReg = /(?:\[spoiler\/?\])(.*?)(?:\/?\[\/spoiler\/?\])/gs;
   // [noparse]Text[/noparse]
-  public noparseTagReg = /(?:\[noparse\/?\])(.*?)(?:\/?\[\/noparse\/?\])/g;
+  public noparseTagReg = /(?:\[noparse\/?\])(.*?)(?:\/?\[\/noparse\/?\])/gs;
   // [img]link[/img]
-  public imgTagReg = /(?:\[img\])(.*?)(?:\[\/img\])/g;
+  public imgTagReg = /(?:\[img\])(.*?)(?:\[\/img\])/gs;
   // [previewyoutube=link][/previewyoutube]
-  public youTubeTagReg = /(?:\[previewyoutube=(.*?)\])(.*?)(?:\[\/previewyoutube\])/g;
+  public youTubeTagReg = /(?:\[previewyoutube=(.*?)\])(.*?)(?:\[\/previewyoutube\])/gs;
+
+  public paragraphReg = /(\n\r?[ ]*){2,}/g;
+
+  public lineBreakReg = /\n\r?/g;
 
   public process(htmlContent: string): string {
     let newContent = htmlContent;
 
+    if (htmlContent.includes('※')) {
+      console.debug('BEFORE');
+      console.debug(htmlContent);
+      console.debug('\n\n');
+    }
     // Remove link hosts
     newContent = newContent.replace(this.linkHostReg, () => '');
     // Remove link filters
@@ -110,6 +119,11 @@ export default class SteamProcessor extends PreProcessor {
 
       return `<ul>${newListContent}</ul>`;
     });
+
+    // Paragraphs and linebreaks
+    newContent = newContent.replace(this.paragraphReg, '</p><p>');
+    newContent = newContent.replace(this.lineBreakReg, '<br>');
+    newContent = `<p>${newContent}</p>`;
 
     return newContent;
   }

--- a/tests/steam_processor.spec.ts
+++ b/tests/steam_processor.spec.ts
@@ -6,7 +6,7 @@ describe('Steam processor', () => {
     describe('lists', () => {
       test('should parse empty list', () => {
         const sampleText = `[list][/list]`;
-        const expected = `<ul></ul>`;
+        const expected = `<p><ul></ul></p>`;
 
         const processor = new SteamProcessor();
         const actual = processor.process(sampleText);
@@ -15,7 +15,7 @@ describe('Steam processor', () => {
       });
       test('should parse empty multiline list', () => {
         const sampleText = `[list]\n\n[/list]`;
-        const expected = `<ul></ul>`;
+        const expected = `<p><ul></ul></p>`;
 
         const processor = new SteamProcessor();
         const actual = processor.process(sampleText);
@@ -24,7 +24,7 @@ describe('Steam processor', () => {
       });
       test('should parse sample list', () => {
         const sampleText = `[list]\n[*] Storm Spirit’s Overload lasts until end of round rather than until Storm spirit's next combat.\n[*] Abaddon’s stats changed from 3/6 -> 2/8 \n[*] Abaddon’s Borrowed Time purges Abaddon and may be used when stunned or silenced. Cooldown reduced from 3 -> 2.\n[*] Abaddon’s Mist Coil self-damage reduced from 3 -> 2.\n[*] Corpse Horde is now an After Combat effect and will spread Zombies more sanely when there is a mix of new Zombies and old units to devour.\n[*] Claszureme Hourglass gives +2 Health.\n[*] No Hesitation and Raid can only be used if there is still a combat phase (i.e. there is only one combat phase per lane).\n[*] Axe’s Berserker’s Call, Keefe the Bold’s Stop Hittin’ Yourself, Shadow Fiend’s Requiem of Souls, Bristleback’s Quill Spray, and Nyctasha’s Guard must have valid targets to use.\n[*] Phase Boots and Rebel Decoy require that both units are not rooted.\n[*] Force Staff cannot target rooted units.\n[/list]`;
-        const expected = `<ul><li>Storm Spirit’s Overload lasts until end of round rather than until Storm spirit's next combat.</li><li>Abaddon’s stats changed from 3/6 -> 2/8</li><li>Abaddon’s Borrowed Time purges Abaddon and may be used when stunned or silenced. Cooldown reduced from 3 -> 2.</li><li>Abaddon’s Mist Coil self-damage reduced from 3 -> 2.</li><li>Corpse Horde is now an After Combat effect and will spread Zombies more sanely when there is a mix of new Zombies and old units to devour.</li><li>Claszureme Hourglass gives +2 Health.</li><li>No Hesitation and Raid can only be used if there is still a combat phase (i.e. there is only one combat phase per lane).</li><li>Axe’s Berserker’s Call, Keefe the Bold’s Stop Hittin’ Yourself, Shadow Fiend’s Requiem of Souls, Bristleback’s Quill Spray, and Nyctasha’s Guard must have valid targets to use.</li><li>Phase Boots and Rebel Decoy require that both units are not rooted.</li><li>Force Staff cannot target rooted units.</li></ul>`;
+        const expected = `<p><ul><li>Storm Spirit’s Overload lasts until end of round rather than until Storm spirit's next combat.</li><li>Abaddon’s stats changed from 3/6 -> 2/8 </li><li>Abaddon’s Borrowed Time purges Abaddon and may be used when stunned or silenced. Cooldown reduced from 3 -> 2.</li><li>Abaddon’s Mist Coil self-damage reduced from 3 -> 2.</li><li>Corpse Horde is now an After Combat effect and will spread Zombies more sanely when there is a mix of new Zombies and old units to devour.</li><li>Claszureme Hourglass gives +2 Health.</li><li>No Hesitation and Raid can only be used if there is still a combat phase (i.e. there is only one combat phase per lane).</li><li>Axe’s Berserker’s Call, Keefe the Bold’s Stop Hittin’ Yourself, Shadow Fiend’s Requiem of Souls, Bristleback’s Quill Spray, and Nyctasha’s Guard must have valid targets to use.</li><li>Phase Boots and Rebel Decoy require that both units are not rooted.</li><li>Force Staff cannot target rooted units.</li></ul></p>`;
 
         const processor = new SteamProcessor();
         const actual = processor.process(sampleText);
@@ -36,7 +36,7 @@ describe('Steam processor', () => {
     test('sample text 01', () => {
       const sampleText = `[i]<a class="bb_link" href="https://steamcommunity.com/linkfilter/?url=https://factorio.com/blog/post/fff-318" target="_blank" rel="noreferrer" >Read this post on our website.</a><span class="bb_link_host">[factorio.com]</span>[/i]<br><br>Hello,<br>we just released 0.17.73, with 0.17.74 coming very soon. This is just some bug fixes and further pathfinding improvements, and we hope to be able to mark the release as Stable next week.<br><br><div class="bb_h1">The new tooltips (Twinsen)</div><br>As part of our big GUI update, I've been working on one particular part: the tooltips. We worked not only on updating the style, but also how the information is structured and sorted, added missing information, removed irrelevant information. This concerns entity, item and recipe tooltips, but almost all tooltips were touched one way or another. Many things were changed. I will go through some of the more important changes. There is also a link [url=https://steamcommunity.com/ogg/593110/announcements/detail/1599264607923965569/]here/[/url/].`;
 
-      const expected = `<i><a class="bb_link" href="https://factorio.com/blog/post/fff-318" target="_blank" rel="noreferrer" >Read this post on our website.</a></i><br><br>Hello,<br>we just released 0.17.73, with 0.17.74 coming very soon. This is just some bug fixes and further pathfinding improvements, and we hope to be able to mark the release as Stable next week.<br><br><h1>The new tooltips (Twinsen)</h1><br>As part of our big GUI update, I've been working on one particular part: the tooltips. We worked not only on updating the style, but also how the information is structured and sorted, added missing information, removed irrelevant information. This concerns entity, item and recipe tooltips, but almost all tooltips were touched one way or another. Many things were changed. I will go through some of the more important changes. There is also a link <a href="https://steamcommunity.com/ogg/593110/announcements/detail/1599264607923965569">here</a>.`;
+      const expected = `<p><i><a class="bb_link" href="https://factorio.com/blog/post/fff-318" target="_blank" rel="noreferrer" >Read this post on our website.</a></i><br><br>Hello,<br>we just released 0.17.73, with 0.17.74 coming very soon. This is just some bug fixes and further pathfinding improvements, and we hope to be able to mark the release as Stable next week.<br><br><h1>The new tooltips (Twinsen)</h1><br>As part of our big GUI update, I've been working on one particular part: the tooltips. We worked not only on updating the style, but also how the information is structured and sorted, added missing information, removed irrelevant information. This concerns entity, item and recipe tooltips, but almost all tooltips were touched one way or another. Many things were changed. I will go through some of the more important changes. There is also a link <a href="https://steamcommunity.com/ogg/593110/announcements/detail/1599264607923965569">here</a>.</p>`;
 
       const processor = new SteamProcessor();
       const actual = processor.process(sampleText);
@@ -48,7 +48,7 @@ describe('Steam processor', () => {
   describe('images', () => {
     test('should parse simple img tag', () => {
       const sampleText = '[img]https://example.com/image.png[/img]';
-      const expected = '<p><img src="https://example.com/image.png" alt="Image"/></p>';
+      const expected = '<p><p><img src="https://example.com/image.png" alt="Image"/></p></p>';
 
       const processor = new SteamProcessor();
       const actual = processor.process(sampleText);
@@ -58,7 +58,7 @@ describe('Steam processor', () => {
     test('should parse img tag with STEAM_CLAN_IMAGE', () => {
       const sampleText = '[img]{STEAM_CLAN_IMAGE}/image.png[/img]';
       const expected =
-        '<p><img src="https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/clans/image.png" alt="Image"/></p>';
+        '<p><p><img src="https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/clans/image.png" alt="Image"/></p></p>';
 
       const processor = new SteamProcessor();
       const actual = processor.process(sampleText);
@@ -70,7 +70,8 @@ describe('Steam processor', () => {
   describe('YouTube previews', () => {
     test('should parse simple previewyoutube tag', () => {
       const sampleText = '[previewyoutube=PVNSct9atp8;full][/previewyoutube]';
-      const expected = '<p><a href="https://youtu.be/PVNSct9atp8;full">YouTube Video</a></p>';
+      const expected =
+        '<p><p><a href="https://youtu.be/PVNSct9atp8;full">YouTube Video</a></p></p>';
 
       const processor = new SteamProcessor();
       const actual = processor.process(sampleText);
@@ -79,7 +80,7 @@ describe('Steam processor', () => {
     });
     test('should parse previewyoutube tag with alt text', () => {
       const sampleText = '[previewyoutube=PVNSct9atp8;full]Alt Text[/previewyoutube]';
-      const expected = '<p><a href="https://youtu.be/PVNSct9atp8;full">Alt Text</a></p>';
+      const expected = '<p><p><a href="https://youtu.be/PVNSct9atp8;full">Alt Text</a></p></p>';
 
       const processor = new SteamProcessor();
       const actual = processor.process(sampleText);
@@ -91,7 +92,7 @@ describe('Steam processor', () => {
   describe('URLs', () => {
     test('should parse simple URL tag', () => {
       const sampleText = '[url=https://github.com]Text[/url]';
-      const expected = '<a href="https://github.com">Text</a>';
+      const expected = '<p><a href="https://github.com">Text</a></p>';
 
       const processor = new SteamProcessor();
       const actual = processor.process(sampleText);
@@ -100,7 +101,7 @@ describe('Steam processor', () => {
     });
     test('should parse URL tag without link text', () => {
       const sampleText = '[url=https://github.com][/url]';
-      const expected = '<a href="https://github.com">Link</a>';
+      const expected = '<p><a href="https://github.com">Link</a></p>';
 
       const processor = new SteamProcessor();
       const actual = processor.process(sampleText);
@@ -112,7 +113,7 @@ describe('Steam processor', () => {
   describe('bold', () => {
     test('should parse simple bold tag', () => {
       const sampleText = '[b]Text[/b]';
-      const expected = '<b>Text</b>';
+      const expected = '<p><b>Text</b></p>';
 
       const processor = new SteamProcessor();
       const actual = processor.process(sampleText);
@@ -124,7 +125,7 @@ describe('Steam processor', () => {
   describe('italic', () => {
     test('should parse simple italic tag', () => {
       const sampleText = '[i]Text[/i]';
-      const expected = '<i>Text</i>';
+      const expected = '<p><i>Text</i></p>';
 
       const processor = new SteamProcessor();
       const actual = processor.process(sampleText);
@@ -136,7 +137,7 @@ describe('Steam processor', () => {
   describe('underline', () => {
     test('should parse simple underline tag', () => {
       const sampleText = '[u]Text[/u]';
-      const expected = '<u>Text</u>';
+      const expected = '<p><u>Text</u></p>';
 
       const processor = new SteamProcessor();
       const actual = processor.process(sampleText);
@@ -148,7 +149,7 @@ describe('Steam processor', () => {
   describe('strikethrough', () => {
     test('should parse simple strikethrough tag', () => {
       const sampleText = '[strike]Text[/strike]';
-      const expected = '<s>Text</s>';
+      const expected = '<p><s>Text</s></p>';
 
       const processor = new SteamProcessor();
       const actual = processor.process(sampleText);
@@ -160,7 +161,7 @@ describe('Steam processor', () => {
   describe('header', () => {
     test('should parse simple h1 tag', () => {
       const sampleText = '[h1]Text[/h1]';
-      const expected = '<h1>Text</h1>';
+      const expected = '<p><h1>Text</h1></p>';
 
       const processor = new SteamProcessor();
       const actual = processor.process(sampleText);
@@ -169,7 +170,7 @@ describe('Steam processor', () => {
     });
     test('should parse simple h2 tag', () => {
       const sampleText = '[h2]Text[/h2]';
-      const expected = '<h2>Text</h2>';
+      const expected = '<p><h2>Text</h2></p>';
 
       const processor = new SteamProcessor();
       const actual = processor.process(sampleText);
@@ -178,7 +179,7 @@ describe('Steam processor', () => {
     });
     test('should parse simple h3 tag', () => {
       const sampleText = '[h3]Text[/h3]';
-      const expected = '<h3>Text</h3>';
+      const expected = '<p><h3>Text</h3></p>';
 
       const processor = new SteamProcessor();
       const actual = processor.process(sampleText);
@@ -187,7 +188,7 @@ describe('Steam processor', () => {
     });
     test('should parse simple h4 tag', () => {
       const sampleText = '[h4]Text[/h4]';
-      const expected = '<h4>Text</h4>';
+      const expected = '<p><h4>Text</h4></p>';
 
       const processor = new SteamProcessor();
       const actual = processor.process(sampleText);
@@ -200,7 +201,7 @@ describe('Steam processor', () => {
     test('should remove linkfilters', () => {
       const sampleText =
         '<a href="https://steamcommunity.com/linkfilter/?url=https://github.com">Text</a>';
-      const expected = '<a href="https://github.com">Text</a>';
+      const expected = '<p><a href="https://github.com">Text</a></p>';
 
       const processor = new SteamProcessor();
       const actual = processor.process(sampleText);
@@ -212,7 +213,7 @@ describe('Steam processor', () => {
   describe('bb header', () => {
     test('should parse bb h1 header', () => {
       const sampleText = '<div class="bb_h1">Text</div>';
-      const expected = '<h1>Text</h1>';
+      const expected = '<p><h1>Text</h1></p>';
 
       const processor = new SteamProcessor();
       const actual = processor.process(sampleText);
@@ -221,7 +222,7 @@ describe('Steam processor', () => {
     });
     test('should parse bb h2 header', () => {
       const sampleText = '<div class="bb_h2">Text</div>';
-      const expected = '<h2>Text</h2>';
+      const expected = '<p><h2>Text</h2></p>';
 
       const processor = new SteamProcessor();
       const actual = processor.process(sampleText);
@@ -230,7 +231,7 @@ describe('Steam processor', () => {
     });
     test('should parse bb h3 header', () => {
       const sampleText = '<div class="bb_h3">Text</div>';
-      const expected = '<h3>Text</h3>';
+      const expected = '<p><h3>Text</h3></p>';
 
       const processor = new SteamProcessor();
       const actual = processor.process(sampleText);
@@ -239,7 +240,7 @@ describe('Steam processor', () => {
     });
     test('should parse bb h4 header', () => {
       const sampleText = '<div class="bb_h4">Text</div>';
-      const expected = '<h4>Text</h4>';
+      const expected = '<p><h4>Text</h4></p>';
 
       const processor = new SteamProcessor();
       const actual = processor.process(sampleText);
@@ -250,8 +251,8 @@ describe('Steam processor', () => {
   // BB Link Hosts
   describe('bb link host', () => {
     test('should remove bb link hosts', () => {
-      const sampleText = '<span class="bb_link_host">[github.com]</span>';
-      const expected = '';
+      const sampleText = '<p><span class="bb_link_host">[github.com]</span></p>';
+      const expected = '<p><p></p></p>';
 
       const processor = new SteamProcessor();
       const actual = processor.process(sampleText);
@@ -263,7 +264,7 @@ describe('Steam processor', () => {
   describe('noparse', () => {
     test('should not change normal text', () => {
       const sampleText = '[noparse]Text[/noparse]';
-      const expected = 'Text';
+      const expected = '<p>Text</p>';
 
       const processor = new SteamProcessor();
       const actual = processor.process(sampleText);
@@ -276,7 +277,7 @@ describe('Steam processor', () => {
     test('should remove spoiler tag', () => {
       // TODO: Add a proper test once the spoiler tag is supported
       const sampleText = '[spoiler]Text[/spoiler]';
-      const expected = 'Text';
+      const expected = '<p>Text</p>';
 
       const processor = new SteamProcessor();
       const actual = processor.process(sampleText);

--- a/tests/steam_processor.spec.ts
+++ b/tests/steam_processor.spec.ts
@@ -120,6 +120,15 @@ describe('Steam processor', () => {
 
       expect(actual).toEqual(expected);
     });
+    test('should parse bold tag with line break', () => {
+      const sampleText = '[b]Text\n[/b]';
+      const expected = '<p><b>Text<br></b></p>';
+
+      const processor = new SteamProcessor();
+      const actual = processor.process(sampleText);
+
+      expect(actual).toEqual(expected);
+    });
   });
   // Italic
   describe('italic', () => {
@@ -278,6 +287,30 @@ describe('Steam processor', () => {
       // TODO: Add a proper test once the spoiler tag is supported
       const sampleText = '[spoiler]Text[/spoiler]';
       const expected = '<p>Text</p>';
+
+      const processor = new SteamProcessor();
+      const actual = processor.process(sampleText);
+
+      expect(actual).toEqual(expected);
+    });
+  });
+  // Paragraphs and line breaks
+  describe('paragraphs and line breaks', () => {
+    test('should convert double line break to paragraph', () => {
+      // TODO: Add a proper test once the spoiler tag is supported
+      const sampleText = 'First\n\nSecond';
+      const expected = '<p>First</p><p>Second</p>';
+
+      const processor = new SteamProcessor();
+      const actual = processor.process(sampleText);
+
+      expect(actual).toEqual(expected);
+    });
+
+    test('should convert line break to <br>', () => {
+      // TODO: Add a proper test once the spoiler tag is supported
+      const sampleText = 'First\nSecond';
+      const expected = '<p>First<br>Second</p>';
 
       const processor = new SteamProcessor();
       const actual = processor.process(sampleText);


### PR DESCRIPTION
**Description**:

This PR doesn't replace the (terrible) regex logic for parsing with a proper parser, but improves the formatting of Steam posts significantly:

- Retain line and paragraph breaks
- Improve parsing of some tags if they include line breaks
- Improve parsing of list tags

**Screenshots**:

Before:
![Formatting of a MIR4 update before the changes. There are many missing line breaks and paragraphs](https://github.com/GameFeeder/GameFeeder/assets/13908946/8b5d28bf-a4f6-46b9-bbce-278e9f01d54d)

After:
![Formatting of the same MIR4 update after the changes. The missing line breaks and paragraphs have been restored](https://github.com/GameFeeder/GameFeeder/assets/13908946/0741ac19-dbe5-4a2c-b8c7-4c1071bc5531)

**Checklist**:

- [x] Tested the bot on both clients with a few commands
- [x] Updated the [`README`](README.md) if necessary
- [x] Updated the version string in the [`package.json`](package.json) if necessary
