### PR TITLE
Fix module resolution

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,33 +1,23 @@
 {
-    "editor.tabSize": 2,
-    "files.eol": "\n",
-    "spellright.documentTypes": [
-        "markdown",
-        "latex",
-        "plaintext"
-    ],
-    "spellright.language": [
-        "en"
-    ],
-    "diffEditor.ignoreTrimWhitespace": false,
-    "files.exclude": {
-        "coverage": true,
-        "dist": true,
-        "node_modules": true,
-        "package-lock.json": true
+  "editor.tabSize": 2,
+  "files.eol": "\n",
+  "spellright.documentTypes": ["markdown", "latex", "plaintext"],
+  "spellright.language": ["en"],
+  "diffEditor.ignoreTrimWhitespace": false,
+  "files.exclude": {
+    "coverage": false,
+    "dist": false,
+    "node_modules": false,
+    "package-lock.json": false
+  },
+  "json.schemas": [
+    {
+      "fileMatch": ["/config/games/*.json"],
+      "url": "./config/schemas/game_config.schema.json"
     },
-    "json.schemas": [
-        {
-            "fileMatch": [
-                "/config/games/*.json"
-            ],
-            "url": "./config/schemas/game_config.schema.json"
-        },
-        {
-            "fileMatch": [
-                "/config/api_config*.json"
-            ],
-            "url": "./config/schemas/api_config.schema.json"
-        }
-    ]
+    {
+      "fileMatch": ["/config/api_config*.json"],
+      "url": "./config/schemas/api_config.schema.json"
+    }
+  ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,5 @@ COPY --from=build-dependencies /app/dist ./dist
 COPY --from=production-dependencies /app/node_modules ./node_modules
 COPY ./config/games ./config/games
 ENV NODE_ENV=production
-ENV NODE_OPTIONS='--experimental-specifier-resolution=node'
 ENV LOG_LEVEL=info
-CMD ["node", "/app/dist/src/_main.js"]
+CMD ["node", "--loader", "commonjs-extension-resolution-loader", "/app/dist/src/_main.js"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.22.2",
       "license": "GPL-3.0",
       "dependencies": {
+        "commonjs-extension-resolution-loader": "^0.1.0",
         "discord.js": "14.14.1",
         "escape-string-regexp": "5.0.0",
         "lodash": "4.17.21",
@@ -3132,6 +3133,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commonjs-extension-resolution-loader": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/commonjs-extension-resolution-loader/-/commonjs-extension-resolution-loader-0.1.0.tgz",
+      "integrity": "sha512-XDCkM/cYIt1CfPs+LNX8nC2KKrzTx5AAlGLpx7A4BjWQCHR9LphDu9Iq5zXYf+PXhCkpLGBFiyiTnwmSnNxbWQ==",
+      "dependencies": {
+        "resolve": "^1.22.1"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4299,7 +4308,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4635,7 +4643,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
       "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -4917,7 +4924,6 @@
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
       "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
-      "dev": true,
       "dependencies": {
         "hasown": "^2.0.0"
       },
@@ -6467,8 +6473,7 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -6799,7 +6804,6 @@
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
       "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dev": true,
       "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -7364,7 +7368,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -10547,6 +10550,14 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "commonjs-extension-resolution-loader": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/commonjs-extension-resolution-loader/-/commonjs-extension-resolution-loader-0.1.0.tgz",
+      "integrity": "sha512-XDCkM/cYIt1CfPs+LNX8nC2KKrzTx5AAlGLpx7A4BjWQCHR9LphDu9Iq5zXYf+PXhCkpLGBFiyiTnwmSnNxbWQ==",
+      "requires": {
+        "resolve": "^1.22.1"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -11416,8 +11427,7 @@
     "function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
     },
     "function.prototype.name": {
       "version": "1.1.5",
@@ -11647,7 +11657,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
       "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.2"
       }
@@ -11849,7 +11858,6 @@
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
       "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
-      "dev": true,
       "requires": {
         "hasown": "^2.0.0"
       }
@@ -13001,8 +13009,7 @@
     "path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-type": {
       "version": "4.0.0",
@@ -13233,7 +13240,6 @@
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
       "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dev": true,
       "requires": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -13657,8 +13663,7 @@
     "supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
     "synckit": {
       "version": "0.8.8",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   },
   "scripts": {
     "build": "tsc --build",
-    "dev": "NODE_OPTIONS='--experimental-specifier-resolution=node' nodemon --watch \"src/**\" --ext \"ts,json\" --exec \"node --loader ts-node/esm src/_main.ts\"",
-    "start": "NODE_OPTIONS='--experimental-specifier-resolution=node' node dist/src/_main.js",
+    "dev": "nodemon --watch \"src/**\" --ext \"ts,json\" --exec \"node --loader ts-node/esm src/_main.ts\"",
+    "start": "node --loader commonjs-extension-resolution-loader dist/src/_main.js",
     "lint": "eslint \"src/**/*.ts\" \"tests/**/*.spec.ts\"",
     "format": "eslint \"src/**/*.ts\" --fix",
     "test": "NODE_OPTIONS='--experimental-vm-modules --experimental-specifier-resolution=node' jest --config jest.config.ts",
@@ -29,6 +29,7 @@
     "watch": "tsc --watch"
   },
   "dependencies": {
+    "commonjs-extension-resolution-loader": "^0.1.0",
     "discord.js": "14.14.1",
     "escape-string-regexp": "5.0.0",
     "lodash": "4.17.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gamefeeder",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "description": "A notification bot for several games, available on Discord and Telegram.",
   "main": "src/_main.ts",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "watch": "tsc --watch"
   },
   "dependencies": {
-    "commonjs-extension-resolution-loader": "^0.1.0",
+    "commonjs-extension-resolution-loader": "0.1.0",
     "discord.js": "14.14.1",
     "escape-string-regexp": "5.0.0",
     "lodash": "4.17.21",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "start": "node --loader commonjs-extension-resolution-loader dist/src/_main.js",
     "lint": "eslint \"src/**/*.ts\" \"tests/**/*.spec.ts\"",
     "format": "eslint \"src/**/*.ts\" --fix",
-    "test": "NODE_OPTIONS='--experimental-vm-modules --experimental-specifier-resolution=node' jest --config jest.config.ts",
-    "coverage": "NODE_OPTIONS='--experimental-vm-modules --experimental-specifier-resolution=node' jest --config jest.config.ts --coverage",
+    "test": "NODE_OPTIONS='--experimental-vm-modules' jest --config jest.config.ts",
+    "coverage": "NODE_OPTIONS='--experimental-vm-modules' jest --config jest.config.ts --coverage",
     "watch": "tsc --watch"
   },
   "dependencies": {


### PR DESCRIPTION
**Description**:

When running `npm run dev`, everything worked fine.
But with `npm run build && npm run start`, we got the following error:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/app/dist/src/logger' imported from /app/dist/src/_main.js
    at finalizeResolution (node:internal/modules/esm/resolve:264:11)
    at moduleResolve (node:internal/modules/esm/resolve:917:10)
    at defaultResolve (node:internal/modules/esm/resolve:1130:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:396:12)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:365:25)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:240:38)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:85:39)
    at link (node:internal/modules/esm/module_job:84:36) {
  code: 'ERR_MODULE_NOT_FOUND',
  url: 'file:///app/dist/src/logger'
}
```

This is because the `--experimental-specifier-resolution=node` flag got removed in <https://github.com/nodejs/node/pull/44859>.
Instead, we now use the `commonjs-extension-resolution-loader` custom loader and specify it with the `--loader` flag.

See also <https://github.com/orgs/nodejs/discussions/46298#discussioncomment-4744722>.

**Checklist**:

- [ ] Tested the bot on both clients with a few commands
- [ ] Updated the [`README`](README.md) if necessary
- [x] Updated the version string in the [`package.json`](package.json) if necessary
