### PR TITLE
Potential fix for code scanning alert no. 7: Inefficient regular expression

### DIFF
--- a/src/processors/steam_processor.ts
+++ b/src/processors/steam_processor.ts
@@ -12,7 +12,7 @@ export default class SteamProcessor extends PreProcessor {
   public linkFilter = /(?:(?<=")https:\/\/steamcommunity\.com\/linkfilter\/\?url=(.*?)(?="))/g;
 
   // [list] ... [/list]
-  public listReg = /(?:\[list\]\s*((?:.|\s)*?)\[\/list\])/gm;
+  public listReg = /\[list\]\s*([^\[]*(?:\[(?!\/list\])[^\[]*)*)\[\/list\]/gm;
   // [*] List item
   public listElemReg = /(?:\[\*\])\s*(.*)\s*/g;
 

--- a/tests/steam_processor.spec.ts
+++ b/tests/steam_processor.spec.ts
@@ -22,6 +22,17 @@ describe('Steam processor', () => {
 
         expect(actual).toEqual(expected);
       });
+      test('should not match unclosed list tag', () => {
+        // Regression: the original (?:.|\\s)*? pattern is ambiguous and
+        // vulnerable to catastrophic backtracking on inputs without a
+        // closing [/list] tag. The fixed tempered-dot pattern fails fast.
+        const processor = new SteamProcessor();
+        const unclosed = `[list]${'item\n'.repeat(20)}`;
+        expect(processor.listReg.test(unclosed)).toBe(false);
+        // Reset lastIndex after stateful global regex test
+        processor.listReg.lastIndex = 0;
+      });
+
       test('should parse sample list', () => {
         const sampleText = `[list]\n[*] Storm Spirit’s Overload lasts until end of round rather than until Storm spirit's next combat.\n[*] Abaddon’s stats changed from 3/6 -> 2/8 \n[*] Abaddon’s Borrowed Time purges Abaddon and may be used when stunned or silenced. Cooldown reduced from 3 -> 2.\n[*] Abaddon’s Mist Coil self-damage reduced from 3 -> 2.\n[*] Corpse Horde is now an After Combat effect and will spread Zombies more sanely when there is a mix of new Zombies and old units to devour.\n[*] Claszureme Hourglass gives +2 Health.\n[*] No Hesitation and Raid can only be used if there is still a combat phase (i.e. there is only one combat phase per lane).\n[*] Axe’s Berserker’s Call, Keefe the Bold’s Stop Hittin’ Yourself, Shadow Fiend’s Requiem of Souls, Bristleback’s Quill Spray, and Nyctasha’s Guard must have valid targets to use.\n[*] Phase Boots and Rebel Decoy require that both units are not rooted.\n[*] Force Staff cannot target rooted units.\n[/list]`;
         const expected = `<p><ul><li>Storm Spirit’s Overload lasts until end of round rather than until Storm spirit's next combat.</li><li>Abaddon’s stats changed from 3/6 -> 2/8 </li><li>Abaddon’s Borrowed Time purges Abaddon and may be used when stunned or silenced. Cooldown reduced from 3 -> 2.</li><li>Abaddon’s Mist Coil self-damage reduced from 3 -> 2.</li><li>Corpse Horde is now an After Combat effect and will spread Zombies more sanely when there is a mix of new Zombies and old units to devour.</li><li>Claszureme Hourglass gives +2 Health.</li><li>No Hesitation and Raid can only be used if there is still a combat phase (i.e. there is only one combat phase per lane).</li><li>Axe’s Berserker’s Call, Keefe the Bold’s Stop Hittin’ Yourself, Shadow Fiend’s Requiem of Souls, Bristleback’s Quill Spray, and Nyctasha’s Guard must have valid targets to use.</li><li>Phase Boots and Rebel Decoy require that both units are not rooted.</li><li>Force Staff cannot target rooted units.</li></ul></p>`;


### PR DESCRIPTION
Potential fix for [https://github.com/GameFeeder/GameFeeder/security/code-scanning/7](https://github.com/GameFeeder/GameFeeder/security/code-scanning/7)

In general, the problem arises because `(?:.|\s)*?` is ambiguous and can match almost any character in many different ways while the engine tries to find `[/list]` after it. To fix it, we should make the repeated portion of the regex unambiguous, usually by restricting what it matches (for example, to anything that is not the start of the closing marker) instead of “any character”.

The current pattern is:

```ts
public listReg = /(?:\[list\]\s*((?:.|\s)*?)\[\/list\])/gm;
```

Functionally, it wants to capture the content between `[list]` and `[/list]`, allowing any text, including newlines. A safer and equivalently expressive approach is to use a negated character class or a tempered dot that never consumes the closing tag. The standard idiom is `[\s\S]*?` or `[\s\S]*?` wrapped in a tempered dot, e.g. `(?:(?!\[\/list\])[\s\S])*`. However, `[\s\S]*?` still has the same ambiguity problem; the key is to prevent the repeated token from matching the start of `[/list]`. The common solution is:

```regex
\[(?:list\])((?:(?!\[\/list\])[\s\S])*)\[\/list\]
```

Here, `(?:(?!\[\/list\])[\s\S])*` says “consume any character that is not the start of `[/list]`”, making backtracking far more constrained and avoiding catastrophic behavior. We keep the original capturing group for the list content and leave flags (`gm`) unchanged. Only line 15 in `src/processors/steam_processor.ts` needs updating; no new imports or helpers are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
