### PR TITLE
feat: add optional BetterStack log forwarding

### DIFF
--- a/config/api_config.example.json
+++ b/config/api_config.example.json
@@ -5,5 +5,6 @@
 
     "discord": { "enabled": false, "prefix": "!", "token": "", "owners": [] }
   },
-  "rollbar": { "enabled": false, "accessToken": "" }
+  "rollbar": { "enabled": false, "accessToken": "" },
+  "betterstack": { "enabled": false, "sourceToken": "" }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.25.0",
       "license": "GPL-3.0",
       "dependencies": {
+        "@logtail/node": "^0.5.8",
+        "@logtail/winston": "^0.5.8",
         "commonjs-extension-resolution-loader": "0.1.0",
         "discord.js": "14.26.3",
         "escape-string-regexp": "5.0.0",
@@ -617,9 +619,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -637,9 +636,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -657,9 +653,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -677,9 +670,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -1472,11 +1462,98 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@logtail/core": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@logtail/core/-/core-0.5.8.tgz",
+      "integrity": "sha512-1LxjI46LCXeVRyENwjO4s0a1CWSIqHjYH6w2YVNhQLc5b7mVN0jhzxvmg9mps54aEuCSuK2SVCNmgvuNTDtAug==",
+      "license": "ISC",
+      "dependencies": {
+        "@logtail/tools": "^0.5.8",
+        "@logtail/types": "^0.5.8",
+        "serialize-error": "8.1.0"
+      }
+    },
+    "node_modules/@logtail/node": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@logtail/node/-/node-0.5.8.tgz",
+      "integrity": "sha512-9XMxeToOL1QHVNp7IQlPxbRsu3iYUBtXl/SFCyOQQmtnwzS7z+tbiV39DYkXfwkzig6wjwTfLYDQj673Bqplqg==",
+      "license": "ISC",
+      "dependencies": {
+        "@logtail/core": "^0.5.8",
+        "@logtail/types": "^0.5.8",
+        "@msgpack/msgpack": "^2.5.1",
+        "@types/stack-trace": "^0.0.33",
+        "minimatch": "^9.0.5",
+        "stack-trace": "0.0.10"
+      }
+    },
+    "node_modules/@logtail/node/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@logtail/node/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@logtail/tools": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@logtail/tools/-/tools-0.5.8.tgz",
+      "integrity": "sha512-eAbbHaYSpRoB7Udp301xVUVDeKdgXTP2/s9FOeKX5tPLMM3hgbvuIx50bYJoV/to7bHGYBi36Gdsnj8ElcPXbg==",
+      "license": "ISC",
+      "dependencies": {
+        "@logtail/types": "^0.5.8"
+      }
+    },
+    "node_modules/@logtail/types": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@logtail/types/-/types-0.5.8.tgz",
+      "integrity": "sha512-CJIijD/2vqK8XwPRZJeUkiiBEhKTviHs5p1WI40WvW21kU18QiQ8PupFJ2uhrItxhwtlkXmRXul5+cNtv3cAFQ==",
+      "license": "ISC"
+    },
+    "node_modules/@logtail/winston": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@logtail/winston/-/winston-0.5.8.tgz",
+      "integrity": "sha512-nL08rAGiKJC4blEBfe4z8sYN4d3G9FCWKlsp8zjcsu42Bj7345hHsgyEfftnhhPWyfmF+5q+i1XucQhjNRSbYQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@logtail/node": "^0.5.8",
+        "@logtail/types": "^0.5.8",
+        "winston-transport": "^4.3.0"
+      },
+      "peerDependencies": {
+        "winston": ">=3.2.1"
+      }
+    },
     "node_modules/@mixmark-io/domino": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
       "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/@msgpack/msgpack": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-2.8.0.tgz",
+      "integrity": "sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
@@ -1824,6 +1901,12 @@
         }
       ]
     },
+    "node_modules/@types/stack-trace": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/stack-trace/-/stack-trace-0.0.33.tgz",
+      "integrity": "sha512-O7in6531Bbvlb2KEsJ0dq0CHZvc3iWSR5ZYMtvGgnHA56VgriAN/AU2LorfmcvAl2xc9N5fbCTRyMRRl8nd74g==",
+      "license": "MIT"
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -1993,9 +2076,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2010,9 +2090,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2027,9 +2104,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2044,9 +2118,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2061,9 +2132,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2078,9 +2146,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2095,9 +2160,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2112,9 +2174,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2428,8 +2487,7 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/base64-arraybuffer": {
       "version": "1.0.2",
@@ -5506,6 +5564,33 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/serialize-error": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
+      "integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/serialize-error/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/shebang-command": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "watch": "tsc --watch"
   },
   "dependencies": {
+    "@logtail/node": "0.5.8",
+    "@logtail/winston": "0.5.8",
     "commonjs-extension-resolution-loader": "0.1.0",
     "discord.js": "14.26.3",
     "escape-string-regexp": "5.0.0",

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -12,7 +12,9 @@ const winstonFormat = Winston.format.combine(
   }),
 );
 
-const winstonLogger = Winston.createLogger({
+// Exported so additional transports (e.g. BetterstackClient) can be attached
+// after initialization without coupling them to this module's internals.
+export const winstonLogger = Winston.createLogger({
   format: winstonFormat,
   level: process.env.LOG_LEVEL || 'debug',
   transports: [new Winston.transports.Console()],

--- a/src/managers/config_manager.ts
+++ b/src/managers/config_manager.ts
@@ -36,7 +36,6 @@ export type RollbarConfig = {
   accessToken: string;
 };
 
-
 /** The configuration settings for BetterStack log forwarding. */
 export type BetterstackConfig = {
   /** Determines whether BetterStack log forwarding is enabled. */
@@ -205,7 +204,6 @@ export default class ConfigManager {
 
     this.setAPIConfig(apiConfig);
   }
-
 
   /** Gets the betterstack config object. */
   public static getBetterstackConfig(): BetterstackConfig | undefined {

--- a/src/managers/config_manager.ts
+++ b/src/managers/config_manager.ts
@@ -36,6 +36,15 @@ export type RollbarConfig = {
   accessToken: string;
 };
 
+
+/** The configuration settings for BetterStack log forwarding. */
+export type BetterstackConfig = {
+  /** Determines whether BetterStack log forwarding is enabled. */
+  enabled: boolean;
+  /** The source token used to authenticate with BetterStack Logs. */
+  sourceToken: string;
+};
+
 /** The configuration settings for the used APIs. */
 export type APIConfig = {
   /** The environment the application is running in (e.g., 'dev', 'production', 'test', 'ci'). */
@@ -44,6 +53,8 @@ export type APIConfig = {
   bots: BotConfig;
   /** The configuration settings for Rollbar error tracking. */
   rollbar: RollbarConfig;
+  /** The configuration settings for BetterStack log forwarding. */
+  betterstack?: BetterstackConfig;
 };
 
 /** An RSS provider. */
@@ -191,6 +202,20 @@ export default class ConfigManager {
   public static setRollbarConfig(config: RollbarConfig): void {
     const apiConfig = this.getAPIConfig();
     apiConfig.rollbar = config;
+
+    this.setAPIConfig(apiConfig);
+  }
+
+
+  /** Gets the betterstack config object. */
+  public static getBetterstackConfig(): BetterstackConfig | undefined {
+    return this.getAPIConfig().betterstack;
+  }
+
+  /** Sets the betterstack config object. */
+  public static setBetterstackConfig(config: BetterstackConfig): void {
+    const apiConfig = this.getAPIConfig();
+    apiConfig.betterstack = config;
 
     this.setAPIConfig(apiConfig);
   }

--- a/src/managers/init_manager.ts
+++ b/src/managers/init_manager.ts
@@ -1,6 +1,7 @@
 import FS from 'fs';
 import _ from 'lodash';
 import Logger from '../logger.js';
+import betterstack_client from '../util/betterstack_client.js';
 import rollbar_client from '../util/rollbar_client.js';
 import { ObjUtil } from '../util/util.js';
 import ConfigManager from './config_manager.js';
@@ -257,6 +258,7 @@ export default class InitManager {
     this.addMissingUserConfigs();
     this.addMissingUserDatas();
     rollbar_client.initialize();
+    betterstack_client.initialize();
 
     // Migrations
     // 1. Rename 'dota' provider to 'dota_patches'

--- a/src/util/betterstack_client.ts
+++ b/src/util/betterstack_client.ts
@@ -1,0 +1,66 @@
+import { Logtail } from '@logtail/node';
+import { LogtailTransport } from '@logtail/winston';
+import Logger, { winstonLogger } from '../logger.js';
+import ConfigManager from '../managers/config_manager.js';
+
+/**
+ * A singleton class for managing the BetterStack (Logtail) log forwarding client.
+ * Mirrors the structure of RollbarClient so either can be removed independently.
+ */
+class BetterstackClient {
+  private static instance: BetterstackClient;
+  private logtail: Logtail | undefined;
+  private logger = new Logger('BetterstackClient');
+
+  /**
+   * Private constructor to enforce singleton pattern
+   */
+  private constructor() {
+    // Explicit initialization required
+  }
+
+  /**
+   * Get the singleton instance of BetterstackClient
+   */
+  public static getInstance(): BetterstackClient {
+    if (!BetterstackClient.instance) {
+      BetterstackClient.instance = new BetterstackClient();
+    }
+    return BetterstackClient.instance;
+  }
+
+  /**
+   * Initialize BetterStack client based on configuration.
+   * When enabled, attaches a LogtailTransport to the shared Winston logger so
+   * all log output is automatically forwarded to BetterStack Logs.
+   */
+  public initialize(): void {
+    if (this.logtail) {
+      return;
+    }
+
+    const betterstackConfig = ConfigManager.getBetterstackConfig();
+
+    if (betterstackConfig?.enabled && betterstackConfig?.sourceToken) {
+      this.logtail = new Logtail(betterstackConfig.sourceToken);
+
+      winstonLogger.add(new LogtailTransport(this.logtail));
+
+      // Flush buffered logs on clean shutdown so nothing is lost
+      for (const signal of ['SIGINT', 'SIGTERM', 'beforeExit'] as const) {
+        process.on(signal, () => {
+          this.logtail?.flush().catch(() => {
+            // Best-effort; the process is already exiting
+          });
+        });
+      }
+
+      this.logger.info('BetterStack client initialized successfully');
+    } else {
+      this.logger.warn('BetterStack client disabled or missing source token');
+    }
+  }
+}
+
+// Export the singleton instance
+export default BetterstackClient.getInstance();


### PR DESCRIPTION
## Summary

Adds [BetterStack Logs](https://betterstack.com/logs) as an optional log forwarding integration alongside the existing Rollbar setup. The two are fully independent — either can be removed without touching the other.

## How it works

When `betterstack.enabled` is `true` and a `sourceToken` is set in `api_config.json`, a `LogtailTransport` is attached to the shared Winston logger during `initAll()`. All log output is then automatically forwarded to BetterStack. If the token is missing or `enabled` is `false`, a warning is logged on startup and everything else continues as normal.

## Changes

- **`src/util/betterstack_client.ts`** — new singleton, mirrors `RollbarClient` structure exactly
- **`src/logger.ts`** — export `winstonLogger` so `BetterstackClient` can attach a transport to it
- **`src/managers/config_manager.ts`** — add `BetterstackConfig` type + `betterstack?` field to `APIConfig`, plus getters/setters
- **`src/managers/init_manager.ts`** — call `betterstack_client.initialize()` alongside `rollbar_client.initialize()` in `initAll()`
- **`config/api_config.example.json`** — add `betterstack` block (disabled by default)
- **`package.json` / `package-lock.json`** — add `@logtail/node` and `@logtail/winston` 0.5.8

## Enabling it

In `config/api_config.json`:
```json
"betterstack": { "enabled": true, "sourceToken": "your-source-token-here" }
```

## Removing either integration

**Remove BetterStack:** delete `src/util/betterstack_client.ts`, remove its `import` and `initialize()` call in `init_manager.ts`, remove the `betterstack` field from `config_manager.ts` and the example config, and `npm uninstall @logtail/node @logtail/winston`.

**Remove Rollbar:** same pattern in reverse. Neither client references the other.