### PR TITLE
Fix for Unreachable statement

### DIFF
--- a/tests/regex.spec.ts
+++ b/tests/regex.spec.ts
@@ -19,7 +19,6 @@ function testRegExp(regExp: RegExp, testStr: string, results: Array<string | und
 
   if (!match) {
     throw new Error(`Not matching '${testStr}'.`);
-    return;
   }
 
   expect(match).toHaveLength(results.length);


### PR DESCRIPTION
The fix is to remove the unreachable `return;` immediately following `throw new Error(...)` in `testRegExp` inside `tests/regex.spec.ts`.

Best single fix without changing functionality:
- Edit `tests/regex.spec.ts` in the `if (!match)` block (around lines 20–23).
- Keep the `throw new Error(...)` line unchanged.
- Delete the subsequent `return;` line.

No imports, new methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._