### PR TITLE
Fix for Useless assignment to local variable

### DIFF
--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -143,22 +143,13 @@ const subCmd = new TwoPartCommand(
 
     // The games matching the alias
     let aliasGames: Game[] = [];
-    let invalidAliases: string[] = [];
-
     for (alias of aliases) {
       const newGames = Game.getGamesByAlias(alias);
-
-      if (newGames.length === 0) {
-        // We don't recognize that alias
-        invalidAliases.push(alias);
-      } else {
-        aliasGames = aliasGames.concat(newGames);
-      }
+      aliasGames = aliasGames.concat(newGames);
     }
 
     // Remove duplicates
     aliasGames = [...new Set(aliasGames)];
-    invalidAliases = [...new Set(invalidAliases)];
 
     // The map of which game is a new sub
     const gameMap = await mapAsync(aliasGames, async (game) => {
@@ -226,22 +217,13 @@ const unsubCmd = new TwoPartCommand(
 
     // The games matching the alias
     let aliasGames: Game[] = [];
-    let invalidAliases: string[] = [];
-
     for (alias of aliases) {
       const newGames = Game.getGamesByAlias(alias);
-
-      if (newGames.length === 0) {
-        // We don't recognize that alias
-        invalidAliases.push(alias);
-      } else {
-        aliasGames = aliasGames.concat(newGames);
-      }
+      aliasGames = aliasGames.concat(newGames);
     }
 
     // Remove duplicates
     aliasGames = [...new Set(aliasGames)];
-    invalidAliases = [...new Set(invalidAliases)];
 
     // The map of which game is a new sub
     const gameMap = aliasGames.map((game) => {


### PR DESCRIPTION
To fix this without changing behavior, remove the unused deduplication assignment to `invalidAliases` at line 161.

Best single fix in this snippet:
- In `src/commands/commands.ts`, in the “Remove duplicates” section, keep deduplication for `aliasGames` (it is used later), and delete the deduplication assignment for `invalidAliases` since its result is never consumed.

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._