### PR TITLE
Migrate Discord bot to slash commands, drop MessageContent intent

### DIFF
--- a/src/bots/discord.ts
+++ b/src/bots/discord.ts
@@ -80,6 +80,17 @@ export default class DiscordBot extends BotClient {
     return toKebabCase(name);
   }
 
+  /** Converts a Discord slash command's (trimmed) 'args' string option into the
+   * CommandGroup 'group' text its regex-based argument parsing expects. That parsing
+   * requires a leading whitespace character (e.g. subscribe's action trigger is
+   * /^\s+.../), which Discord's trimmed string option never includes on its own.
+   *
+   * @param argsString - The raw value of the 'args' string option.
+   */
+  public static toCommandGroupArgs(argsString: string): string {
+    return argsString ? ` ${argsString}` : '';
+  }
+
   public static getBot(): DiscordBot {
     if (this.standardBot) {
       return this.standardBot;
@@ -391,10 +402,8 @@ export default class DiscordBot extends BotClient {
       const message = new Message(user, channel, argsString, timestamp);
       // The command's own trigger has already been matched by Discord (it invoked this
       // exact slash command), so we only need to carry the remaining free text along as
-      // the 'group' the command's regex-based argument parsing expects. That parsing
-      // requires a leading whitespace character (e.g. subscribe's action trigger is
-      // /^\s+.../), which Discord's trimmed string option never includes on its own.
-      const groupString = argsString ? ` ${argsString}` : '';
+      // the 'group' the command's regex-based argument parsing expects.
+      const groupString = DiscordBot.toCommandGroupArgs(argsString);
       const fakeMatch = { groups: { group: groupString } } as unknown as RegExpMatchArray;
 
       try {

--- a/src/bots/discord.ts
+++ b/src/bots/discord.ts
@@ -30,7 +30,7 @@ import User, { UserRole } from '../user.js';
 import { mapAsync } from '../util/array_util.js';
 import MDRegex from '../util/regex.js';
 import rollbar_client from '../util/rollbar_client.js';
-import { assertIsDefined, StrUtil } from '../util/util.js';
+import { assertIsDefined, StrUtil, toKebabCase } from '../util/util.js';
 import { BotClient } from './bot.js';
 
 /** The maximum amount of characters allowed in the title of embeds. */
@@ -75,7 +75,7 @@ export default class DiscordBot extends BotClient {
    * @param name - The internal command name.
    */
   public static toSlashCommandName(name: string): string {
-    return name.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
+    return toKebabCase(name);
   }
 
   public static getBot(): DiscordBot {

--- a/src/bots/discord.ts
+++ b/src/bots/discord.ts
@@ -1,6 +1,7 @@
 import {
   ActivityType,
   APIEmbed,
+  BaseGuildTextChannel,
   Client,
   DMChannel,
   EmbedBuilder,
@@ -196,7 +197,8 @@ export default class DiscordBot extends BotClient {
     if (discordChannel instanceof DMChannel) {
       return UserRole.ADMIN;
     }
-    if (discordChannel instanceof TextChannel) {
+    // Covers both TextChannel and NewsChannel (announcement channels)
+    if (discordChannel instanceof BaseGuildTextChannel) {
       // Check if the user is an admin on this channel
       const discordUser = discordChannel.members.get(user.id);
       if (discordUser?.permissions.has(PermissionsBitField.Flags.Administrator)) {
@@ -226,7 +228,8 @@ export default class DiscordBot extends BotClient {
       return new Permissions(true, true, true, true);
     }
 
-    if (discordChannel instanceof TextChannel) {
+    // Covers both TextChannel and NewsChannel (announcement channels)
+    if (discordChannel instanceof BaseGuildTextChannel) {
       try {
         // Check for the permissions
         const discordUser = discordChannel.members.get(user.id);
@@ -274,7 +277,8 @@ export default class DiscordBot extends BotClient {
     if (discordChannel instanceof DMChannel) {
       // You always have all permissions in DM and group channels
       canEmbed = true;
-    } else if (discordChannel instanceof TextChannel) {
+    } else if (discordChannel instanceof BaseGuildTextChannel) {
+      // Covers both TextChannel and NewsChannel (announcement channels)
       // Check for the permissions
       const discordUser = discordChannel.members.get(user.id);
       canEmbed = discordUser
@@ -732,15 +736,13 @@ export default class DiscordBot extends BotClient {
     };
 
     try {
-      if (discordChannel instanceof DMChannel) {
+      // Covers DMChannel, TextChannel, NewsChannel (announcement channels), and any other
+      // channel type that supports .send() - unlike the previous DMChannel/TextChannel-only
+      // check, which silently dropped replies in e.g. announcement channels.
+      if (discordChannel.isSendable()) {
         await discordChannel.send(discordMessage);
         return true;
       }
-      if (discordChannel instanceof TextChannel) {
-        await discordChannel.send(discordMessage);
-        return true;
-      }
-      // Group DMs seem to be deprecated
     } catch (error) {
       rollbar_client.reportCaughtError(
         `Failed to send message to channel ${channel.label}`,

--- a/src/bots/discord.ts
+++ b/src/bots/discord.ts
@@ -386,7 +386,12 @@ export default class DiscordBot extends BotClient {
       const channel = this.getChannelByID(interaction.channelId);
       const user = new User(this, interaction.user.id);
       const argsString = interaction.options.getString('args') ?? '';
-      const message = new Message(user, channel, argsString, new Date());
+      const now = new Date();
+      // Use the interaction's own creation time (clamped in case of clock skew) so that
+      // /ping and command-duration logging measure actual delivery latency, rather than
+      // just the time since this handler started running.
+      const timestamp = interaction.createdAt > now ? now : interaction.createdAt;
+      const message = new Message(user, channel, argsString, timestamp);
       // The command's own trigger has already been matched by Discord (it invoked this
       // exact slash command), so we only need to carry the remaining free text along as
       // the 'group' the command's regex-based argument parsing expects. That parsing

--- a/src/bots/discord.ts
+++ b/src/bots/discord.ts
@@ -8,6 +8,7 @@ import {
   HexColorString,
   MessageCreateOptions,
   MessageFlags,
+  Partials,
   PermissionsBitField,
   PresenceData,
   RESTPostAPIChatInputApplicationCommandsJSONBody,
@@ -59,6 +60,10 @@ export default class DiscordBot extends BotClient {
         GatewayIntentBits.Guilds,
         GatewayIntentBits.GuildMessages,
       ],
+      // Without this, DM interactions resolve to an uncached channel (the client only
+      // caches a channel from interaction data when its partial is enabled), which makes
+      // permission checks fail closed and wrongly wipes the channel's subscription data.
+      partials: [Partials.Channel],
     });
   }
 

--- a/src/bots/discord.ts
+++ b/src/bots/discord.ts
@@ -10,6 +10,7 @@ import {
   MessageCreateOptions,
   MessageFlags,
   Partials,
+  PermissionFlagsBits,
   PermissionsBitField,
   PresenceData,
   RESTPostAPIChatInputApplicationCommandsJSONBody,
@@ -353,6 +354,14 @@ export default class DiscordBot extends BotClient {
         builder.addStringOption((option) =>
           option.setName('args').setDescription('Arguments for the command.').setRequired(false),
         );
+      }
+
+      if (cmd.role === UserRole.ADMIN || cmd.role === UserRole.OWNER) {
+        // Hide admin/owner-only commands from the slash command picker for regular
+        // members by default. This is only a UX/discoverability measure - Discord's
+        // permission model has no concept of our bot-configured OWNER role, so
+        // Command.execute's role check below remains the actual security boundary.
+        builder.setDefaultMemberPermissions(PermissionFlagsBits.Administrator);
       }
 
       this.slashCommands.push(builder.toJSON());

--- a/src/bots/discord.ts
+++ b/src/bots/discord.ts
@@ -7,12 +7,16 @@ import {
   GatewayIntentBits,
   HexColorString,
   MessageCreateOptions,
+  MessageFlags,
   PermissionsBitField,
   PresenceData,
+  RESTPostAPIChatInputApplicationCommandsJSONBody,
+  SlashCommandBuilder,
   TextChannel,
 } from 'discord.js';
 import Channel from '../channel.js';
 import Command from '../commands/command.js';
+import CommandGroup from '../commands/command_group.js';
 import Game from '../game.js';
 import ConfigManager from '../managers/config_manager.js';
 import ProjectManager from '../managers/project_manager.js';
@@ -36,6 +40,10 @@ const EMBED_CONTENT_LIMIT = 2048;
 export default class DiscordBot extends BotClient {
   private static standardBot: DiscordBot;
   private bot: Client;
+  /** The slash commands registered with Discord, keyed by their (kebab-case) name. */
+  private commandByName: Map<string, Command> = new Map();
+  /** The slash command definitions to register with the Discord API on startup. */
+  private slashCommands: RESTPostAPIChatInputApplicationCommandsJSONBody[] = [];
 
   constructor(
     prefix: string,
@@ -50,9 +58,17 @@ export default class DiscordBot extends BotClient {
         GatewayIntentBits.DirectMessages,
         GatewayIntentBits.Guilds,
         GatewayIntentBits.GuildMessages,
-        GatewayIntentBits.MessageContent,
       ],
     });
+  }
+
+  /** Converts a command's internal camelCase name to a Discord-legal, lowercase, kebab-case
+   * slash command name (e.g. 'notifyGameSubs' -> 'notify-game-subs').
+   *
+   * @param name - The internal command name.
+   */
+  public static toSlashCommandName(name: string): string {
+    return name.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
   }
 
   public static getBot(): DiscordBot {
@@ -312,22 +328,68 @@ export default class DiscordBot extends BotClient {
   }
 
   public registerCommand(command: Command): void {
-    this.bot.on('messageCreate', async (msg) => {
-      const channel = this.getChannelByID(msg.channel.id);
-      const user = new User(this, msg.author.id);
-      const now = new Date();
-      // Ensure proper timestamp
-      const timestamp = msg.createdAt > now ? now : msg.createdAt;
-      const content = msg.toString();
+    if (!(command instanceof CommandGroup)) {
+      throw new Error('Discord bot can only register a CommandGroup as its root command.');
+    }
 
-      const reg = await command.getRegExp(channel);
-      // Run regex on the msg
-      const regMatch = reg.exec(content);
-      const message = new Message(user, channel, content, timestamp);
-      // If the regex matched, execute the handler function
-      if (regMatch) {
-        // Execute the command
-        await command.execute(message, regMatch);
+    // Build the slash command definitions from the top-level commands
+    this.slashCommands = [];
+    this.commandByName = new Map();
+
+    for (const cmd of command.commands) {
+      const builder = new SlashCommandBuilder()
+        .setName(DiscordBot.toSlashCommandName(cmd.name))
+        .setDescription(cmd.description.slice(0, 100));
+
+      if (cmd instanceof CommandGroup) {
+        // Command groups (e.g. TwoPartCommands) take free-text arguments, parsed the same
+        // way as on Telegram, via a single string option.
+        builder.addStringOption((option) =>
+          option.setName('args').setDescription('Arguments for the command.').setRequired(false),
+        );
+      }
+
+      this.slashCommands.push(builder.toJSON());
+      this.commandByName.set(builder.name, cmd);
+    }
+
+    this.bot.on('interactionCreate', async (interaction) => {
+      if (!interaction.isChatInputCommand()) {
+        return;
+      }
+
+      const cmd = this.commandByName.get(interaction.commandName);
+      if (!cmd) {
+        this.logger.warn(`Received unknown slash command '${interaction.commandName}'.`);
+        return;
+      }
+
+      const channel = this.getChannelByID(interaction.channelId);
+      const user = new User(this, interaction.user.id);
+      const argsString = interaction.options.getString('args') ?? '';
+      const message = new Message(user, channel, argsString, new Date());
+      // The command's own trigger has already been matched by Discord (it invoked this
+      // exact slash command), so we only need to carry the remaining free text along as
+      // the 'group' the command's regex-based argument parsing expects.
+      const fakeMatch = { groups: { group: argsString } } as unknown as RegExpMatchArray;
+
+      try {
+        // Interactions must be acknowledged within 3 seconds. The command's actual reply is
+        // sent as a normal channel message below, so this placeholder is deleted afterwards.
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+      } catch (error) {
+        rollbar_client.reportCaughtError(
+          `Failed to acknowledge Discord interaction for command '${interaction.commandName}'`,
+          error,
+          this.logger,
+        );
+        return;
+      }
+
+      try {
+        await cmd.execute(message, fakeMatch);
+      } finally {
+        await interaction.deleteReply().catch(() => undefined);
       }
     });
   }
@@ -350,6 +412,25 @@ export default class DiscordBot extends BotClient {
     // Start the bot
     await this.bot.login(this.token);
     this.isRunning = true;
+
+    // Register the slash commands with Discord
+    if (this.bot.application) {
+      try {
+        await this.bot.application.commands.set(this.slashCommands);
+      } catch (error) {
+        rollbar_client.reportCaughtError(
+          `Failed to register Discord slash commands`,
+          error,
+          this.logger,
+        );
+      }
+    } else {
+      rollbar_client.warning(
+        'Discord application not found, could not register slash commands',
+        this.bot,
+      );
+      this.logger.error('Discord application not found, could not register slash commands');
+    }
 
     // Setup the user
     const user = this.bot.user;

--- a/src/bots/discord.ts
+++ b/src/bots/discord.ts
@@ -370,8 +370,11 @@ export default class DiscordBot extends BotClient {
       const message = new Message(user, channel, argsString, new Date());
       // The command's own trigger has already been matched by Discord (it invoked this
       // exact slash command), so we only need to carry the remaining free text along as
-      // the 'group' the command's regex-based argument parsing expects.
-      const fakeMatch = { groups: { group: argsString } } as unknown as RegExpMatchArray;
+      // the 'group' the command's regex-based argument parsing expects. That parsing
+      // requires a leading whitespace character (e.g. subscribe's action trigger is
+      // /^\s+.../), which Discord's trimmed string option never includes on its own.
+      const groupString = argsString ? ` ${argsString}` : '';
+      const fakeMatch = { groups: { group: groupString } } as unknown as RegExpMatchArray;
 
       try {
         // Interactions must be acknowledged within 3 seconds. The command's actual reply is

--- a/src/bots/discord.ts
+++ b/src/bots/discord.ts
@@ -397,6 +397,12 @@ export default class DiscordBot extends BotClient {
 
       try {
         await cmd.execute(message, fakeMatch);
+      } catch (error) {
+        rollbar_client.reportCaughtError(
+          `Failed to execute Discord command '${interaction.commandName}'`,
+          error,
+          this.logger,
+        );
       } finally {
         await interaction.deleteReply().catch(() => undefined);
       }

--- a/src/bots/discord.ts
+++ b/src/bots/discord.ts
@@ -50,11 +50,12 @@ export default class DiscordBot extends BotClient {
   private slashCommands: RESTPostAPIChatInputApplicationCommandsJSONBody[] = [];
 
   constructor(
-    prefix: string,
     private token: string,
     autostart: boolean,
   ) {
-    super('discord', 'Discord', prefix, autostart);
+    // Discord only uses slash commands, which are always triggered with '/'; unlike
+    // Telegram, its prefix isn't configurable.
+    super('discord', 'Discord', '/', autostart);
 
     // Set up the bot
     this.bot = new Client({
@@ -84,13 +85,9 @@ export default class DiscordBot extends BotClient {
       return this.standardBot;
     }
     // Discord Bot
-    const {
-      prefix: discordPrefix,
-      token: discordToken,
-      enabled: discordAutostart,
-    } = ConfigManager.getBotConfig().discord;
+    const { token: discordToken, enabled: discordAutostart } = ConfigManager.getBotConfig().discord;
 
-    this.standardBot = new DiscordBot(discordPrefix, discordToken, discordAutostart);
+    this.standardBot = new DiscordBot(discordToken, discordAutostart);
     return this.standardBot;
   }
 

--- a/src/bots/discord.ts
+++ b/src/bots/discord.ts
@@ -4,6 +4,7 @@ import {
   Client,
   DMChannel,
   EmbedBuilder,
+  Events,
   GatewayIntentBits,
   HexColorString,
   MessageCreateOptions,
@@ -417,8 +418,17 @@ export default class DiscordBot extends BotClient {
     this.setupUpdaterSubscription();
     this.setupEveryoneSubscription();
 
+    // client.application (and client.user) are only guaranteed to be populated once the
+    // client emits 'clientReady' - login() itself can resolve before that happens, since
+    // the underlying gateway shard reports its own low-level ready state first. Attach the
+    // listener before logging in to avoid a race with the event firing early.
+    const clientReady = new Promise<void>((resolve) => {
+      this.bot.once(Events.ClientReady, () => resolve());
+    });
+
     // Start the bot
     await this.bot.login(this.token);
+    await clientReady;
     this.isRunning = true;
 
     // Register the slash commands with Discord

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -54,10 +54,6 @@ export default class Channel {
   }
 
   get prefix(): string {
-    if (this.bot.name === 'discord') {
-      // Discord only uses slash commands, which are always triggered with '/'.
-      return '/';
-    }
     if (this._prefix) {
       return this._prefix;
     }

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -54,9 +54,9 @@ export default class Channel {
   }
 
   get prefix(): string {
-    if (this._prefix) {
-      return this._prefix;
-    }
+    // Per-channel custom prefixes are no longer configurable (there's no command left to
+    // set, discover, or reset one), so always fall back to the bot's default prefix, even
+    // for channels that persisted a custom _prefix before that command was removed.
     return this.bot.prefix;
   }
 

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -54,6 +54,10 @@ export default class Channel {
   }
 
   get prefix(): string {
+    if (this.bot.name === 'discord') {
+      // Discord only uses slash commands, which are always triggered with '/'.
+      return '/';
+    }
     if (this._prefix) {
       return this._prefix;
     }

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -62,63 +62,6 @@ const aboutCmd = new NoLabelAction(
   },
 );
 
-/** Prefix command, used to change the prefix of the bot on that channel. */
-const prefixCmd = new TwoPartCommand(
-  'prefix',
-  `Change the bot's prefix used in this channel.`,
-  'prefix <new prefix>',
-  // Group trigger
-  /^\s*prefix(?<group>.*)$/,
-  // Actiont trigger
-  /^\s*(?<newPrefix>.+?)\s*$/,
-  // Action
-  async (message, match) => {
-    const bot = message.getBot();
-    const channel = message.channel;
-    const user = await bot.getUser();
-    let { newPrefix } = matchGroups(match);
-    newPrefix = newPrefix ? newPrefix.trim() : '';
-
-    // Check if the bot can write to this channel
-    const permissions = await bot.getUserPermissions(user, channel);
-
-    if (!permissions) {
-      rollbar_client.warning(
-        `Failed to get bot permissions while assigning new prefix for channel`,
-        channel,
-        permissions,
-        user,
-      );
-      bot.logger.error(
-        `Failed to get bot permissions while assigning new prefix for channel ${channel.label}.`,
-      );
-      return;
-    }
-
-    if (!permissions.canWrite) {
-      if (bot.removeData(channel)) {
-        bot.logger.warn(`Can't write to channel ${channel.label}, removing all data.`);
-      }
-      return;
-    }
-
-    channel.prefix = newPrefix;
-  },
-  // Default action
-  async (message) => {
-    if (message.isEmpty()) {
-      const prefix = message.channel.prefix;
-      await message.reply(
-        `The prefix currently used on this channel is \`${prefix}\`.\n` +
-          `Use \`${prefix}prefix <new prefix>\` to use another prefix.\n` +
-          `Use \`${prefix}prefix reset\` to reset the prefix to the default` +
-          `(\`${message.getBot().prefix}\`).`,
-      );
-    }
-  },
-  UserRole.ADMIN,
-);
-
 /** Subscribe command, used to subscribe to a game. */
 const subCmd = new TwoPartCommand(
   'subscribe',
@@ -299,13 +242,7 @@ const settingsCmd = new NoLabelAction(
         : '> You are currently not subscribed to any games.';
 
     await message.reply(
-      `You can use \`${commands.tryFindCmdLabel(
-        prefixCmd,
-        message.channel,
-      )}\` to change the prefix the bot uses ` +
-        `on this channel.\n` +
-        `> The prefix currently used on this channel is \`${channel.prefix}\`.\n` +
-        `You can use \`${commands.tryFindCmdLabel(subCmd, message.channel)}\` and ` +
+      `You can use \`${commands.tryFindCmdLabel(subCmd, message.channel)}\` and ` +
         `\`${commands.tryFindCmdLabel(
           unsubCmd,
           message.channel,
@@ -871,7 +808,6 @@ const commands: CommandGroup = new CommandGroup(
     // Admin commands
     subCmd,
     unsubCmd,
-    prefixCmd,
     // Owner commands
     notifyAllCmd,
     notifyGameSubsCmd,

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -10,7 +10,7 @@ import { UserRole } from '../user.js';
 import { mapAsync, naturalJoin } from '../util/array_util.js';
 import constants from '../util/constants.js';
 import rollbar_client from '../util/rollbar_client.js';
-import { matchGroups } from '../util/util.js';
+import { matchGroups, toKebabCase } from '../util/util.js';
 import Command from './command.js';
 import CommandGroup from './command_group.js';
 import NoLabelAction from './no_label_action.js';
@@ -768,9 +768,18 @@ const commands: CommandGroup = new CommandGroup(
   // Help
   (channel, prefix, role) => {
     const cmdPrefix = channel.prefix;
-    const cmdLabels = Command.filterByRole(commands.commands, role || UserRole.OWNER).map(
-      (cmd) => `${prefix}${cmd.channelHelp(channel, cmdPrefix)}`,
-    );
+    const cmdLabels = Command.filterByRole(commands.commands, role || UserRole.OWNER).map((cmd) => {
+      const helpText = cmd.channelHelp(channel, cmdPrefix);
+      // Discord's slash command names are kebab-case (e.g. 'notifyGameSubs' is registered
+      // as 'notify-game-subs'), unlike the camelCase internal names used everywhere else
+      // (including Telegram's BotFather registration). Rewrite the leading name in the
+      // rendered label so the displayed syntax is actually typeable on Discord.
+      const displayText =
+        channel.bot.name === 'discord'
+          ? helpText.replace(`${cmdPrefix}${cmd.name}`, `${cmdPrefix}${toKebabCase(cmd.name)}`)
+          : helpText;
+      return `${prefix}${displayText}`;
+    });
     return cmdLabels.join('\n');
   },
   // Trigger: The channels prefix, e.g. '/' for Telegram

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -1,6 +1,7 @@
 import EscapeRegex from 'escape-string-regexp';
 import PubSub from 'pubsub-js';
 import getBots from '../bots/bots.js';
+import Channel from '../channel.js';
 import Game from '../game.js';
 import ProjectManager from '../managers/project_manager.js';
 import Notification from '../notifications/notification.js';
@@ -753,6 +754,24 @@ const labelCmd = new TwoPartCommand(
   UserRole.OWNER,
 );
 
+/** Renders a single command's help line. Discord's slash command names are kebab-case
+ * (e.g. 'notifyGameSubs' is registered as 'notify-game-subs'), unlike the camelCase
+ * internal names used everywhere else (including Telegram's BotFather registration), so
+ * the leading name is rewritten for Discord channels to keep the displayed syntax
+ * actually typeable there.
+ *
+ * @param cmd - The command to render the help line for.
+ * @param channel - The channel to render the help line for.
+ * @param cmdPrefix - The command prefix to use, i.e. channel.prefix.
+ */
+export function renderCmdHelpLine(cmd: Command, channel: Channel, cmdPrefix: string): string {
+  const helpText = cmd.channelHelp(channel, cmdPrefix);
+  if (channel.bot.name !== 'discord') {
+    return helpText;
+  }
+  return helpText.replace(`${cmdPrefix}${cmd.name}`, `${cmdPrefix}${toKebabCase(cmd.name)}`);
+}
+
 /**
  * The group containing all available commands.
  * They share the channels prefix as prefix, e.g. '/' for Telegram.
@@ -768,18 +787,9 @@ const commands: CommandGroup = new CommandGroup(
   // Help
   (channel, prefix, role) => {
     const cmdPrefix = channel.prefix;
-    const cmdLabels = Command.filterByRole(commands.commands, role || UserRole.OWNER).map((cmd) => {
-      const helpText = cmd.channelHelp(channel, cmdPrefix);
-      // Discord's slash command names are kebab-case (e.g. 'notifyGameSubs' is registered
-      // as 'notify-game-subs'), unlike the camelCase internal names used everywhere else
-      // (including Telegram's BotFather registration). Rewrite the leading name in the
-      // rendered label so the displayed syntax is actually typeable on Discord.
-      const displayText =
-        channel.bot.name === 'discord'
-          ? helpText.replace(`${cmdPrefix}${cmd.name}`, `${cmdPrefix}${toKebabCase(cmd.name)}`)
-          : helpText;
-      return `${prefix}${displayText}`;
-    });
+    const cmdLabels = Command.filterByRole(commands.commands, role || UserRole.OWNER).map(
+      (cmd) => `${prefix}${renderCmdHelpLine(cmd, channel, cmdPrefix)}`,
+    );
     return cmdLabels.join('\n');
   },
   // Trigger: The channels prefix, e.g. '/' for Telegram

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -25,6 +25,14 @@ export function matchGroups(match: RegExpMatchArray): { [key: string]: string } 
   return match.groups;
 }
 
+/** Converts a camelCase identifier to lowercase, kebab-case (e.g. 'notifyGameSubs' ->
+ * 'notify-game-subs'). Used to derive Discord-legal slash command names from the internal
+ * camelCase command names, which stay camelCase for Telegram's BotFather registration.
+ */
+export function toKebabCase(name: string): string {
+  return name.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
+}
+
 /** Utility functions for strings. */
 export class StrUtil {
   /** Limits the given string to the given maximum length.

--- a/tests/channel.spec.ts
+++ b/tests/channel.spec.ts
@@ -55,3 +55,23 @@ describe.skip('Channel', () => {
     expect(testChannel.hasLabel).toBeFalsy();
   });
 });
+
+describe('Channel prefix fallback', () => {
+  const mockBot = new MockBot();
+
+  test('falls back to the bot prefix when no custom prefix is set', () => {
+    const channel = new Channel('mockChannel', mockBot);
+
+    expect(channel.prefix).toEqual(mockBot.prefix);
+  });
+
+  test('ignores a persisted custom prefix, always using the bot prefix', () => {
+    // Simulates a channel that persisted a custom prefix before the /prefix command was
+    // removed from both bots - there's no longer any way to discover, change, or reset
+    // it, so it should no longer take effect.
+    const channel = new Channel('mockChannel', mockBot, [], 'customPrefix');
+
+    expect(channel.prefix).toEqual(mockBot.prefix);
+    expect(channel.prefix).not.toEqual('customPrefix');
+  });
+});

--- a/tests/commands.spec.ts
+++ b/tests/commands.spec.ts
@@ -1,0 +1,35 @@
+import Channel from 'src/channel.js';
+import Action from 'src/commands/action.js';
+import { renderCmdHelpLine } from 'src/commands/commands.js';
+import MockBot from './mockClasses/mockBot.js';
+
+describe('renderCmdHelpLine', () => {
+  const action = new Action(
+    'notifyGameSubs',
+    'Notify the subs of a game',
+    'notifyGameSubs (<game name>) <message>',
+    /^\s*notifyGameSubs\s*$/,
+    // eslint-disable-next-line require-await
+    async () => {},
+  );
+
+  test('keeps the internal camelCase name for non-Discord bots', () => {
+    const bot = new MockBot();
+    const channel = new Channel('mockChannel', bot);
+
+    const line = renderCmdHelpLine(action, channel, '/');
+
+    expect(line).toContain('/notifyGameSubs');
+  });
+
+  test('rewrites the leading command name to kebab-case for Discord', () => {
+    const bot = new MockBot();
+    bot.name = 'discord';
+    const channel = new Channel('mockChannel', bot);
+
+    const line = renderCmdHelpLine(action, channel, '/');
+
+    expect(line).toContain('/notify-game-subs');
+    expect(line).not.toContain('/notifyGameSubs');
+  });
+});

--- a/tests/discord.spec.ts
+++ b/tests/discord.spec.ts
@@ -1,4 +1,11 @@
+import { Partials, PermissionFlagsBits } from 'discord.js';
 import DiscordBot from 'src/bots/discord.js';
+import Channel from 'src/channel.js';
+import Action from 'src/commands/action.js';
+import CommandGroup from 'src/commands/command_group.js';
+import Message from 'src/message.js';
+import User, { UserRole } from 'src/user.js';
+import MockBot from './mockClasses/mockBot.js';
 
 describe('Discord bot', () => {
   describe('message from markdown', () => {
@@ -308,6 +315,133 @@ describe('Discord bot', () => {
 
     test('lowercases a trailing acronym-like segment', () => {
       expect(DiscordBot.toSlashCommandName('telegramCmds')).toEqual('telegram-cmds');
+    });
+  });
+
+  // COMMAND GROUP ARGUMENT BRIDGING
+  describe('command group argument bridging', () => {
+    // Mirrors the leading-whitespace-anchored shape of the real action triggers in
+    // src/commands/commands.ts (subscribe, unsubscribe, notifyAll, notifyGameSubs all
+    // require a leading whitespace character to separate the command word from its
+    // arguments), without depending on that module's heavyweight game/provider loading.
+    const leadingWhitespaceTrigger = /^\s+(?<value>.+?)\s*$/;
+    const action = new Action(
+      'test-action',
+      'Test action',
+      'test <value>',
+      leadingWhitespaceTrigger,
+      // eslint-disable-next-line require-await
+      async () => {},
+    );
+
+    const mockBot = new MockBot();
+    const mockChannel = new Channel('mockChannel', mockBot);
+    const mockUser = new User(mockBot, 'mockUser');
+
+    test('empty args produce an empty group', () => {
+      expect(DiscordBot.toCommandGroupArgs('')).toEqual('');
+    });
+
+    test('non-empty args are prefixed with a space', () => {
+      expect(DiscordBot.toCommandGroupArgs('dota2')).toEqual(' dota2');
+    });
+
+    test('the bridged group matches a leading-whitespace action trigger', () => {
+      const groupString = DiscordBot.toCommandGroupArgs('dota2');
+      const message = new Message(mockUser, mockChannel, groupString, new Date());
+
+      expect(action.test(message)).toBeTruthy();
+    });
+
+    test('the raw (unbridged) args string does not match, reproducing the bug this fixes', () => {
+      const message = new Message(mockUser, mockChannel, 'dota2', new Date());
+
+      expect(action.test(message)).toBeUndefined();
+    });
+  });
+
+  // CLIENT SETUP
+  describe('client setup', () => {
+    test('the underlying Discord client is created with the Channel partial enabled', () => {
+      const bot = new DiscordBot('mock-token', false);
+
+      // Without this, DM interactions resolve to an uncached channel, which silently
+      // wipes the channel's subscription data (see src/bots/discord.ts).
+      expect(bot['bot'].options.partials).toContain(Partials.Channel);
+    });
+  });
+
+  // REGISTER COMMAND
+  describe('registerCommand', () => {
+    const userCmd = new Action('ping', 'A user command', 'ping', /^\s*ping\s*$/, async () => {
+      /* noop */
+    });
+    const adminGroupCmd = new CommandGroup(
+      'subscribe',
+      'An admin command group',
+      () => 'subscribe',
+      (channel, prefix) => `${prefix}subscribe`,
+      () => /^\s*subscribe(?<group>.*)$/,
+      async () => {
+        /* noop */
+      },
+      [],
+      UserRole.ADMIN,
+    );
+    const ownerCmd = new Action(
+      'notifyAll',
+      'An owner command',
+      'notifyAll',
+      /^\s*notifyAll\s*$/,
+      async () => {
+        /* noop */
+      },
+      UserRole.OWNER,
+    );
+    const rootGroup = new CommandGroup(
+      'root',
+      'Root',
+      () => '',
+      () => '',
+      () => /^$/,
+      async () => {
+        /* noop */
+      },
+      [userCmd, adminGroupCmd, ownerCmd],
+    );
+
+    function buildSlashCommands() {
+      const bot = new DiscordBot('mock-token', false);
+      bot.registerCommand(rootGroup);
+      return bot['slashCommands'];
+    }
+
+    test('a plain user command gets no args option and no default member permissions', () => {
+      const slashCommands = buildSlashCommands();
+      const cmd = slashCommands.find((c) => c.name === 'ping');
+
+      expect(cmd?.options ?? []).toEqual([]);
+      expect(cmd?.default_member_permissions).toBeUndefined();
+    });
+
+    test('a command group gets an optional args string option', () => {
+      const slashCommands = buildSlashCommands();
+      const cmd = slashCommands.find((c) => c.name === 'subscribe');
+
+      expect(cmd?.options).toEqual([expect.objectContaining({ name: 'args', required: false })]);
+    });
+
+    test('admin and owner commands default to requiring the Administrator permission', () => {
+      const slashCommands = buildSlashCommands();
+      const adminCmd = slashCommands.find((c) => c.name === 'subscribe');
+      const ownerCmd = slashCommands.find((c) => c.name === 'notify-all');
+
+      expect(adminCmd?.default_member_permissions).toEqual(
+        PermissionFlagsBits.Administrator.toString(),
+      );
+      expect(ownerCmd?.default_member_permissions).toEqual(
+        PermissionFlagsBits.Administrator.toString(),
+      );
     });
   });
 });

--- a/tests/discord.spec.ts
+++ b/tests/discord.spec.ts
@@ -291,4 +291,23 @@ describe('Discord bot', () => {
       expect(testEmbed).toEqual(expected);
     });
   });
+
+  // SLASH COMMAND NAME
+  describe('slash command name', () => {
+    test('single lowercase word is unchanged', () => {
+      expect(DiscordBot.toSlashCommandName('roll')).toEqual('roll');
+    });
+
+    test('camelCase word is converted to kebab-case', () => {
+      expect(DiscordBot.toSlashCommandName('notifyAll')).toEqual('notify-all');
+    });
+
+    test('multi-word camelCase word is converted to kebab-case', () => {
+      expect(DiscordBot.toSlashCommandName('notifyGameSubs')).toEqual('notify-game-subs');
+    });
+
+    test('lowercases a trailing acronym-like segment', () => {
+      expect(DiscordBot.toSlashCommandName('telegramCmds')).toEqual('telegram-cmds');
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Discord commands are now dispatched via native slash commands (`interactionCreate`) instead of regex-matching raw message text, so the privileged `MessageContent` gateway intent is no longer requested.
- Each command's existing free-text argument parsing (`src/commands/commands.ts`) is reused unchanged — every `TwoPartCommand` gets a single optional `args` string option whose value feeds straight into the existing regex parsers, so no command logic changed.
- `/prefix` is removed from both bots (customizing a text prefix no longer makes sense once Discord only understands slash commands); `Channel.prefix` now always resolves to the bot's default prefix (`/` for Discord, hardcoded on `DiscordBot` rather than special-cased in the platform-neutral `Channel`).
- Telegram is untouched apart from losing `/prefix` — it keeps using the existing prefix/regex-based text-command pipeline.

## Review fixes
An `/code-review ultra` pass on the initial version found 10 issues, all fixed here in individual follow-up commits:
- **Args never matched.** Discord trims the `args` string option, but subscribe/unsubscribe/notifyAll/notifyGameSubs all require a leading whitespace character in their action trigger regex, so these commands were silently broken.
- **DM interactions wiped subscriptions.** Without `Partials.Channel`, a DM's channel resolved as uncached/undefined, which made permission checks fail closed and caused `sendMessage` to delete that channel's subscription data.
- **Command registration could race `client.application`.** `login()` can resolve before the READY payload sets `client.application`; registration now waits on `clientReady` instead.
- **Unhandled promise rejection.** A throwing command action escaped the interaction handler uncaught; now reported via `rollbar_client`.
- **Owner/admin commands were visible to everyone.** They now default to requiring the Administrator permission in the picker (the real enforcement remains `Command.execute`'s role check).
- **Help text showed untypeable camelCase names** (e.g. `/notifyGameSubs`) instead of Discord's actual kebab-case registered names (`/notify-game-subs`).
- **Announcement channels got silent no-op replies.** Permission checks and reply delivery only recognized `TextChannel`/`DMChannel`; widened to `BaseGuildTextChannel` (covers `NewsChannel`) and `isSendable()`. Thread channels remain a known, separate gap.
- **`/ping`/`/debug` measured the wrong thing.** Now uses `interaction.createdAt` (clamped for clock skew) instead of handler-local time, matching the old `msg.createdAt` behavior.
- **Stale per-channel prefixes.** With `/prefix` gone, `Channel.prefix` no longer honors a previously-persisted custom prefix — any channel that had set one now falls back to the bot's default.

## Test coverage
Two internal helpers (`DiscordBot.toCommandGroupArgs`, `renderCmdHelpLine`) were pulled out of their closures specifically to make them unit-testable, and regression tests were added for 5 of the 10 fixes above (the leading-whitespace args bug, the `Partials.Channel` fix, the default-member-permissions fix, the kebab-case help text fix, and the stale-prefix fix) — each verified by hand to fail against the pre-fix code and pass against the fix. The other 5 (the `clientReady` race, the execute try/catch, and the `BaseGuildTextChannel`/`isSendable` widening) would need new discord.js entity/gateway mocking infrastructure this repo doesn't have — same gap that already existed for the pre-PR `messageCreate` handler — so they still rely on the manual verification below.

## Test plan
- [x] `npm run build`
- [x] `npm run biome:check`
- [x] `npm test`
- [ ] Manually verify in a real Discord dev server (can't be covered by unit tests):
  - [ ] Bot starts and commands register without the `MessageContent` intent enabled
  - [ ] No-arg command (`/help`, `/ping`)
  - [ ] Free-text command (`/roll args:"2d20+3"`, `/subscribe args:"<a game>"`)
  - [ ] Owner-only command as both an owner and a non-owner (role gating), including that it's hidden from non-admins in the picker
  - [ ] A DM command doesn't wipe DM subscription data
  - [ ] A command in an announcement channel actually replies
  - [ ] Reply lands as a normal channel message/embed, ephemeral "thinking" placeholder disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)